### PR TITLE
Add Go CI quality gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,45 @@
 name: Go
 
-on: [push]
+on:
+  pull_request:
+  push:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  quality:
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Run Go tests
+      run: go test -count=1 ./...
+
+    - name: Run go vet
+      run: go vet ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs: quality
+    if: github.event_name == 'push'
+
+    permissions:
+      contents: read
       packages: write
-   
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- add a separate Go quality job that runs tests and vet on pushes and pull requests
- gate Docker image publishing behind the quality job
- keep Docker publishing limited to push events

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "YAML syntax OK"'`
- `go test -count=1 ./...`
- `go vet ./...`

Note: `actionlint` was not installed locally, so workflow syntax validation was limited to YAML parsing before opening the PR.