### PR TITLE
Add title normalization rules v2

### DIFF
--- a/internal/courses/catalog_test.go
+++ b/internal/courses/catalog_test.go
@@ -294,10 +294,18 @@ func TestBuildGzipWithTitleRulesNormalizesTransliteratedTitleWithoutChangingIden
 	source := validSource(t, entry)
 	expectedID := courseID(courseIdentityKey(source.Source.ChannelID, entry))
 	rules := titleRulesForTest(t, `{
-		"schema_version":"title-normalization-rules/v1",
+		"schema_version":"title-normalization-rules/v2",
 		"protected_tokens_ci":[],
 		"protected_tokens_exact":[],
-		"protected_substrings_ci":[]
+		"protected_substrings_ci":[],
+		"force_normalize_tokens_ci":[],
+		"force_normalize_phrases_ci":[],
+		"structural_cleanup":{
+			"decode_html_entities":false,
+			"drop_zero_width_format_chars":false,
+			"underscores_as_spaces":false,
+			"strip_leading_provider_noise":false
+		}
 	}`)
 
 	var output bytes.Buffer
@@ -326,6 +334,52 @@ func TestBuildGzipWithTitleRulesNormalizesTransliteratedTitleWithoutChangingIden
 	}
 	if !slices.Contains(got.Categories, "data_ai") {
 		t.Fatalf("categories = %v, want normalized title to classify as data_ai", got.Categories)
+	}
+}
+
+func TestBuildGzipCountsCleanupOnlyTitleWithoutChangingIdentity(t *testing.T) {
+	entry := validSourceEntry()
+	entry.Title = `"'9.[Provider]_Alpha__Beta`
+	entry.RawBlock = entry.Title
+	source := validSource(t, entry)
+	expectedID := courseID(courseIdentityKey(source.Source.ChannelID, entry))
+	rules := titleRulesForTest(t, `{
+		"schema_version":"title-normalization-rules/v2",
+		"protected_tokens_ci":[],
+		"protected_tokens_exact":[],
+		"protected_substrings_ci":[],
+		"force_normalize_tokens_ci":[],
+		"force_normalize_phrases_ci":[],
+		"structural_cleanup":{
+			"decode_html_entities":true,
+			"drop_zero_width_format_chars":true,
+			"underscores_as_spaces":true,
+			"strip_leading_provider_noise":true
+		}
+	}`)
+
+	var output bytes.Buffer
+	stats, err := BuildGzipFromSourcesWithOptions(
+		[]SourceInput{{Reader: sourceReader(t, source), Name: "synthetic.json"}},
+		&output,
+		BuildOptions{TitleRules: rules},
+	)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	if stats.NormalizedTitles != 1 {
+		t.Fatalf("normalized title count = %d, want 1", stats.NormalizedTitles)
+	}
+
+	got := decodeBuiltCatalog(t, &output).Entries[0]
+	if got.ID != expectedID {
+		t.Fatalf("course ID = %q, want raw-title identity %q", got.ID, expectedID)
+	}
+	if got.Title != "[Provider] Alpha Beta" {
+		t.Fatalf("title = %q, want cleanup-only title", got.Title)
+	}
+	if got.TitleOriginal == nil || *got.TitleOriginal != entry.Title {
+		t.Fatalf("title_original = %v, want raw title %q", got.TitleOriginal, entry.Title)
 	}
 }
 
@@ -433,10 +487,18 @@ func TestBuildGzipCountsMergedNormalizedTitleOnce(t *testing.T) {
 
 	var output bytes.Buffer
 	rules := titleRulesForTest(t, `{
-		"schema_version":"title-normalization-rules/v1",
+		"schema_version":"title-normalization-rules/v2",
 		"protected_tokens_ci":[],
 		"protected_tokens_exact":[],
-		"protected_substrings_ci":[]
+		"protected_substrings_ci":[],
+		"force_normalize_tokens_ci":[],
+		"force_normalize_phrases_ci":[],
+		"structural_cleanup":{
+			"decode_html_entities":false,
+			"drop_zero_width_format_chars":false,
+			"underscores_as_spaces":false,
+			"strip_leading_provider_noise":false
+		}
 	}`)
 	stats, err := BuildGzipFromSourcesWithOptions(
 		[]SourceInput{{Reader: sourceReader(t, source), Name: "synthetic.json"}},

--- a/internal/courses/title_normalization.go
+++ b/internal/courses/title_normalization.go
@@ -121,6 +121,7 @@ func (normalizer titleNormalizer) cleanup(title string) string {
 	if normalizer.rules == nil {
 		return title
 	}
+	original := title
 	cleanup := normalizer.rules.structuralCleanup
 	if cleanup.decodeHTMLEntities {
 		title = html.UnescapeString(title)
@@ -139,20 +140,63 @@ func (normalizer titleNormalizer) cleanup(title string) string {
 	if cleanup.underscoresAsSpaces {
 		title = cleanupCourseTitleUnderscores(title)
 	}
+	if !hasVisibleCourseTitleContent(title) {
+		return original
+	}
 	return title
 }
 
 func cleanupCourseTitleUnderscores(title string) string {
-	fields := strings.Fields(title)
-	cleaned := make([]string, 0, len(fields))
-	for _, field := range fields {
-		if preserveCourseTitleUnderscores(field, len(fields) > 1) {
-			cleaned = append(cleaned, field)
+	if !strings.Contains(title, "_") {
+		return title
+	}
+
+	embedded := len(strings.Fields(title)) > 1
+	var cleaned strings.Builder
+	cleaned.Grow(len(title))
+	for offset := 0; offset < len(title); {
+		r, size := utf8.DecodeRuneInString(title[offset:])
+		if unicode.IsSpace(r) {
+			cleaned.WriteString(title[offset : offset+size])
+			offset += size
 			continue
 		}
-		cleaned = append(cleaned, strings.Fields(strings.ReplaceAll(field, "_", " "))...)
+
+		end := offset + size
+		for end < len(title) {
+			r, size = utf8.DecodeRuneInString(title[end:])
+			if unicode.IsSpace(r) {
+				break
+			}
+			end += size
+		}
+		field := title[offset:end]
+		if preserveCourseTitleUnderscores(field, embedded) {
+			cleaned.WriteString(field)
+		} else {
+			cleaned.WriteString(replaceCourseTitleFieldUnderscores(field))
+		}
+		offset = end
 	}
-	return strings.Join(cleaned, " ")
+	return cleaned.String()
+}
+
+func replaceCourseTitleFieldUnderscores(field string) string {
+	var cleaned strings.Builder
+	cleaned.Grow(len(field))
+	for offset := 0; offset < len(field); {
+		if field[offset] != '_' {
+			_, size := utf8.DecodeRuneInString(field[offset:])
+			cleaned.WriteString(field[offset : offset+size])
+			offset += size
+			continue
+		}
+		cleaned.WriteByte(' ')
+		for offset < len(field) && field[offset] == '_' {
+			offset++
+		}
+	}
+	return cleaned.String()
 }
 
 func preserveCourseTitleUnderscores(field string, embedded bool) bool {
@@ -191,6 +235,15 @@ func isASCIIUppercaseIdentifierPart(value string) bool {
 		}
 	}
 	return hasLetter
+}
+
+func hasVisibleCourseTitleContent(title string) bool {
+	for _, r := range title {
+		if !unicode.IsSpace(r) && !unicode.Is(unicode.Cf, r) {
+			return true
+		}
+	}
+	return false
 }
 
 func stripLeadingProviderNoise(title string) string {

--- a/internal/courses/title_normalization.go
+++ b/internal/courses/title_normalization.go
@@ -187,7 +187,7 @@ func (normalizer titleNormalizer) forceNormalizeWholeTitle(tokens []courseTitleT
 		return false
 	}
 	for _, token := range tokens {
-		if !token.word {
+		if !token.word || token.protected {
 			continue
 		}
 		if _, forced := normalizer.rules.forceNormalizeTokensCI[strings.ToLower(token.text)]; forced {
@@ -208,7 +208,7 @@ func courseTitleContainsPhrase(tokens []courseTitleToken, phrase string) bool {
 		return false
 	}
 	for start, token := range tokens {
-		if !token.word || !strings.EqualFold(token.text, words[0]) {
+		if !token.word || token.protected || !strings.EqualFold(token.text, words[0]) {
 			continue
 		}
 		index := start
@@ -216,7 +216,7 @@ func courseTitleContainsPhrase(tokens []courseTitleToken, phrase string) bool {
 		for _, word := range words[1:] {
 			var ok bool
 			index, ok = nextWhitespaceSeparatedCourseTitleWord(tokens, index)
-			if !ok || !strings.EqualFold(tokens[index].text, word) {
+			if !ok || tokens[index].protected || !strings.EqualFold(tokens[index].text, word) {
 				matches = false
 				break
 			}

--- a/internal/courses/title_normalization.go
+++ b/internal/courses/title_normalization.go
@@ -1,6 +1,7 @@
 package courses
 
 import (
+	"html"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -77,21 +78,18 @@ func normalizeCourseTitle(title string) (string, bool) {
 }
 
 func (normalizer titleNormalizer) Normalize(title string) (string, bool) {
+	original := title
+	title = normalizer.cleanup(title)
 	tokens := normalizer.tokenize(title)
-	forcedTokens := forcedCourseTitleTokens(tokens)
-	score := scoreCourseTitle(tokens, forcedTokens)
-	normalizeWholeTitle := score >= 4
-	if !normalizeWholeTitle && len(forcedTokens) == 0 {
-		return title, false
+	normalizeWholeTitle := scoreCourseTitle(tokens) >= 4 ||
+		normalizer.forceNormalizeWholeTitle(tokens)
+	if !normalizeWholeTitle {
+		return title, title != original
 	}
 
 	var normalized strings.Builder
 	normalized.Grow(len(title))
-	for index, token := range tokens {
-		if !normalizeWholeTitle && !forcedTokens[index] {
-			normalized.WriteString(token.text)
-			continue
-		}
+	for _, token := range tokens {
 		if !token.word || token.protected || !isLatinCourseTitleToken(token.text) {
 			normalized.WriteString(token.text)
 			continue
@@ -102,7 +100,7 @@ func (normalizer titleNormalizer) Normalize(title string) (string, bool) {
 			strings.ToLower(token.text),
 		)
 		if err != nil {
-			return title, false
+			return original, false
 		}
 		if startsWithASCIICapital(token.text) {
 			first, size := utf8.DecodeRuneInString(value)
@@ -112,7 +110,122 @@ func (normalizer titleNormalizer) Normalize(title string) (string, bool) {
 	}
 
 	result := normalized.String()
-	return result, result != title
+	return result, result != original
+}
+
+func (normalizer titleNormalizer) cleanup(title string) string {
+	if normalizer.rules == nil {
+		return title
+	}
+	cleanup := normalizer.rules.structuralCleanup
+	if cleanup.decodeHTMLEntities {
+		title = html.UnescapeString(title)
+	}
+	if cleanup.dropZeroWidthFormatChars {
+		title = strings.Map(func(r rune) rune {
+			if unicode.Is(unicode.Cf, r) {
+				return -1
+			}
+			return r
+		}, title)
+	}
+	if cleanup.underscoresAsSpaces {
+		title = strings.ReplaceAll(title, "_", " ")
+		title = strings.Join(strings.Fields(title), " ")
+	}
+	if cleanup.stripLeadingProviderNoise {
+		title = stripLeadingProviderNoise(title)
+	}
+	return title
+}
+
+func stripLeadingProviderNoise(title string) string {
+	offset := 0
+	removed := false
+	for offset < len(title) {
+		r, size := utf8.DecodeRuneInString(title[offset:])
+		if !isCourseTitleQuote(r) {
+			break
+		}
+		offset += size
+		removed = true
+	}
+
+	ordinalStart := offset
+	for offset < len(title) && title[offset] >= '0' && title[offset] <= '9' {
+		offset++
+	}
+	if offset > ordinalStart && offset < len(title) && title[offset] == '.' {
+		offset++
+		removed = true
+	} else {
+		offset = ordinalStart
+	}
+	if !removed ||
+		offset >= len(title) ||
+		title[offset] != '[' {
+		return title
+	}
+	closeOffset := strings.IndexByte(title[offset+1:], ']')
+	if closeOffset <= 0 {
+		return title
+	}
+	return title[offset:]
+}
+
+func isCourseTitleQuote(r rune) bool {
+	switch r {
+	case '\'', '"', '‘', '’', '“', '”', '„', '«', '»':
+		return true
+	default:
+		return false
+	}
+}
+
+func (normalizer titleNormalizer) forceNormalizeWholeTitle(tokens []courseTitleToken) bool {
+	if normalizer.rules == nil {
+		return false
+	}
+	for _, token := range tokens {
+		if !token.word {
+			continue
+		}
+		if _, forced := normalizer.rules.forceNormalizeTokensCI[strings.ToLower(token.text)]; forced {
+			return true
+		}
+	}
+	for _, phrase := range normalizer.rules.forceNormalizePhrasesCI {
+		if courseTitleContainsPhrase(tokens, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func courseTitleContainsPhrase(tokens []courseTitleToken, phrase string) bool {
+	words := strings.Fields(phrase)
+	if len(words) == 0 {
+		return false
+	}
+	for start, token := range tokens {
+		if !token.word || !strings.EqualFold(token.text, words[0]) {
+			continue
+		}
+		index := start
+		matches := true
+		for _, word := range words[1:] {
+			var ok bool
+			index, ok = nextWhitespaceSeparatedCourseTitleWord(tokens, index)
+			if !ok || !strings.EqualFold(tokens[index].text, word) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }
 
 func (normalizer titleNormalizer) tokenize(title string) []courseTitleToken {
@@ -273,12 +386,9 @@ func (normalizer titleNormalizer) protectToken(token courseTitleToken) bool {
 	return letters > 0 && upper == letters
 }
 
-func scoreCourseTitle(tokens []courseTitleToken, forcedTokens map[int]bool) int {
+func scoreCourseTitle(tokens []courseTitleToken) int {
 	score := 0
-	for index, token := range tokens {
-		if forcedTokens[index] {
-			continue
-		}
+	for _, token := range tokens {
 		if !token.word || token.protected || !isLatinCourseTitleToken(token.text) {
 			continue
 		}
@@ -352,38 +462,6 @@ func scoreCourseTitleMarkers(value string) int {
 	return score
 }
 
-func forcedCourseTitleTokens(tokens []courseTitleToken) map[int]bool {
-	forced := make(map[int]bool)
-	for index := range tokens {
-		if tokens[index].word &&
-			!tokens[index].protected &&
-			strings.EqualFold(tokens[index].text, "freymvork") {
-			forced[index] = true
-		}
-	}
-
-	for index := range tokens {
-		if !tokens[index].word ||
-			tokens[index].protected ||
-			!strings.EqualFold(tokens[index].text, "c") {
-			continue
-		}
-		number, ok := nextWhitespaceSeparatedCourseTitleWord(tokens, index)
-		if !ok || !isASCIIDigits(tokens[number].text) {
-			continue
-		}
-		last, ok := nextWhitespaceSeparatedCourseTitleWord(tokens, number)
-		if !ok ||
-			tokens[last].protected ||
-			!strings.EqualFold(tokens[last].text, "do") {
-			continue
-		}
-		forced[index] = true
-		forced[last] = true
-	}
-	return forced
-}
-
 func nextWhitespaceSeparatedCourseTitleWord(tokens []courseTitleToken, index int) (int, bool) {
 	index++
 	if index >= len(tokens) || !courseTitleTokenIsSpace(tokens[index]) {
@@ -418,16 +496,4 @@ func isASCIILetter(r rune) bool {
 
 func isASCIIAlphaNumeric(r rune) bool {
 	return isASCIILetter(r) || r >= '0' && r <= '9'
-}
-
-func isASCIIDigits(value string) bool {
-	if value == "" {
-		return false
-	}
-	for _, r := range value {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/courses/title_normalization.go
+++ b/internal/courses/title_normalization.go
@@ -59,10 +59,11 @@ var courseTitleReverseTranslit = translit.Map(map[string]string{
 })
 
 type courseTitleToken struct {
-	text      string
-	word      bool
-	bracketed bool
-	protected bool
+	text             string
+	word             bool
+	bracketed        bool
+	protected        bool
+	forceOverridable bool
 }
 
 type titleNormalizer struct {
@@ -90,7 +91,10 @@ func (normalizer titleNormalizer) Normalize(title string) (string, bool) {
 	var normalized strings.Builder
 	normalized.Grow(len(title))
 	for _, token := range tokens {
-		if !token.word || token.protected || !isLatinCourseTitleToken(token.text) {
+		forcedToken := normalizer.isForcedToken(token)
+		if !token.word ||
+			(token.protected && !(token.forceOverridable && forcedToken)) ||
+			!isLatinCourseTitleToken(token.text) {
 			normalized.WriteString(token.text)
 			continue
 		}
@@ -187,10 +191,8 @@ func (normalizer titleNormalizer) forceNormalizeWholeTitle(tokens []courseTitleT
 		return false
 	}
 	for _, token := range tokens {
-		if !token.word || token.protected {
-			continue
-		}
-		if _, forced := normalizer.rules.forceNormalizeTokensCI[strings.ToLower(token.text)]; forced {
+		if normalizer.isForcedToken(token) &&
+			(!token.protected || token.forceOverridable) {
 			return true
 		}
 	}
@@ -200,6 +202,14 @@ func (normalizer titleNormalizer) forceNormalizeWholeTitle(tokens []courseTitleT
 		}
 	}
 	return false
+}
+
+func (normalizer titleNormalizer) isForcedToken(token courseTitleToken) bool {
+	if normalizer.rules == nil || !token.word {
+		return false
+	}
+	_, forced := normalizer.rules.forceNormalizeTokensCI[strings.ToLower(token.text)]
+	return forced
 }
 
 func courseTitleContainsPhrase(tokens []courseTitleToken, phrase string) bool {
@@ -250,7 +260,7 @@ func (normalizer titleNormalizer) tokenize(title string) []courseTitleToken {
 				word:      true,
 				bracketed: bracketDepth > 0 || parenDepth > 0,
 			}
-			token.protected = normalizer.protectToken(token)
+			token.protected, token.forceOverridable = normalizer.protectToken(token)
 			tokens = append(tokens, token)
 			title = title[end:]
 			continue
@@ -290,6 +300,7 @@ func protectNetworkCourseTitleFields(tokens []courseTitleToken) {
 			for index := start; index < end; index++ {
 				if tokens[index].word {
 					tokens[index].protected = true
+					tokens[index].forceOverridable = false
 				}
 			}
 		}
@@ -342,30 +353,30 @@ func isCourseTitleWordRuneAt(value string, offset int) bool {
 		r == '/'
 }
 
-func (normalizer titleNormalizer) protectToken(token courseTitleToken) bool {
+func (normalizer titleNormalizer) protectToken(token courseTitleToken) (protected, forceOverridable bool) {
 	if token.bracketed {
-		return true
+		return true, false
 	}
 
 	lower := strings.ToLower(token.text)
 	if normalizer.rules != nil {
 		if _, protected := normalizer.rules.protectedTokensExact[token.text]; protected {
-			return true
+			return true, false
 		}
 		if _, protected := normalizer.rules.protectedTokensCI[lower]; protected {
-			return true
+			return true, false
 		}
 		for _, substring := range normalizer.rules.protectedSubstringsCI {
 			if strings.Contains(lower, substring) {
-				return true
+				return true, false
 			}
 		}
 	}
 	if strings.ContainsAny(token.text, "0123456789_@/:") {
-		return true
+		return true, false
 	}
 	if startsWithASCIICapital(token.text) && containsEnglishCourseTitleMarker(lower) {
-		return true
+		return true, true
 	}
 
 	letters := 0
@@ -379,11 +390,14 @@ func (normalizer titleNormalizer) protectToken(token courseTitleToken) bool {
 		if r >= 'A' && r <= 'Z' {
 			upper++
 			if index > 0 && !(index == 1 && allowUpperSHPrefix) {
-				return true
+				return true, true
 			}
 		}
 	}
-	return letters > 0 && upper == letters
+	if letters > 0 && upper == letters {
+		return true, true
+	}
+	return false, false
 }
 
 func scoreCourseTitle(tokens []courseTitleToken) int {

--- a/internal/courses/title_normalization.go
+++ b/internal/courses/title_normalization.go
@@ -133,14 +133,64 @@ func (normalizer titleNormalizer) cleanup(title string) string {
 			return r
 		}, title)
 	}
-	if cleanup.underscoresAsSpaces {
-		title = strings.ReplaceAll(title, "_", " ")
-		title = strings.Join(strings.Fields(title), " ")
-	}
 	if cleanup.stripLeadingProviderNoise {
 		title = stripLeadingProviderNoise(title)
 	}
+	if cleanup.underscoresAsSpaces {
+		title = cleanupCourseTitleUnderscores(title)
+	}
 	return title
+}
+
+func cleanupCourseTitleUnderscores(title string) string {
+	fields := strings.Fields(title)
+	cleaned := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if preserveCourseTitleUnderscores(field, len(fields) > 1) {
+			cleaned = append(cleaned, field)
+			continue
+		}
+		cleaned = append(cleaned, strings.Fields(strings.ReplaceAll(field, "_", " "))...)
+	}
+	return strings.Join(cleaned, " ")
+}
+
+func preserveCourseTitleUnderscores(field string, embedded bool) bool {
+	if !strings.Contains(field, "_") {
+		return false
+	}
+	if strings.Contains(field, "://") ||
+		strings.Contains(field, "@") ||
+		strings.ContainsAny(field, `/\`) ||
+		looksLikeCourseTitleDomain(strings.ReplaceAll(field, "_", "-")) {
+		return true
+	}
+	if !embedded {
+		return false
+	}
+	if strings.ContainsAny(field, "0123456789") {
+		return true
+	}
+	for _, part := range strings.Split(field, "_") {
+		if len(part) > 1 && isASCIIUppercaseIdentifierPart(part) {
+			return true
+		}
+	}
+	return false
+}
+
+func isASCIIUppercaseIdentifierPart(value string) bool {
+	hasLetter := false
+	for _, r := range value {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasLetter = true
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return hasLetter
 }
 
 func stripLeadingProviderNoise(title string) string {

--- a/internal/courses/title_normalization.go
+++ b/internal/courses/title_normalization.go
@@ -124,7 +124,7 @@ func (normalizer titleNormalizer) cleanup(title string) string {
 	original := title
 	cleanup := normalizer.rules.structuralCleanup
 	if cleanup.decodeHTMLEntities {
-		title = html.UnescapeString(title)
+		title = unescapeStrictCourseTitleEntities(title)
 	}
 	if cleanup.dropZeroWidthFormatChars {
 		title = strings.Map(func(r rune) rune {
@@ -144,6 +144,74 @@ func (normalizer titleNormalizer) cleanup(title string) string {
 		return original
 	}
 	return title
+}
+
+func unescapeStrictCourseTitleEntities(title string) string {
+	if !strings.Contains(title, "&") {
+		return title
+	}
+
+	var decoded strings.Builder
+	decoded.Grow(len(title))
+	for offset := 0; offset < len(title); {
+		relativeAmpersand := strings.IndexByte(title[offset:], '&')
+		if relativeAmpersand < 0 {
+			decoded.WriteString(title[offset:])
+			break
+		}
+
+		ampersand := offset + relativeAmpersand
+		decoded.WriteString(title[offset:ampersand])
+		end, ok := strictCourseTitleEntityEnd(title, ampersand)
+		if !ok {
+			decoded.WriteByte('&')
+			offset = ampersand + 1
+			continue
+		}
+		decoded.WriteString(html.UnescapeString(title[ampersand:end]))
+		offset = end
+	}
+	return decoded.String()
+}
+
+func strictCourseTitleEntityEnd(title string, ampersand int) (int, bool) {
+	index := ampersand + 1
+	if index >= len(title) {
+		return 0, false
+	}
+
+	if title[index] == '#' {
+		index++
+		if index < len(title) && (title[index] == 'x' || title[index] == 'X') {
+			index++
+			digitsStart := index
+			for index < len(title) && isASCIIHexDigit(title[index]) {
+				index++
+			}
+			return index + 1, index > digitsStart && index < len(title) && title[index] == ';'
+		}
+
+		digitsStart := index
+		for index < len(title) && title[index] >= '0' && title[index] <= '9' {
+			index++
+		}
+		return index + 1, index > digitsStart && index < len(title) && title[index] == ';'
+	}
+
+	if !isASCIILetter(rune(title[index])) {
+		return 0, false
+	}
+	index++
+	for index < len(title) && isASCIIAlphaNumeric(rune(title[index])) {
+		index++
+	}
+	return index + 1, index < len(title) && title[index] == ';'
+}
+
+func isASCIIHexDigit(value byte) bool {
+	return value >= '0' && value <= '9' ||
+		value >= 'a' && value <= 'f' ||
+		value >= 'A' && value <= 'F'
 }
 
 func cleanupCourseTitleUnderscores(title string) string {
@@ -247,6 +315,10 @@ func hasVisibleCourseTitleContent(title string) bool {
 }
 
 func stripLeadingProviderNoise(title string) string {
+	if hasPairedOuterCourseTitleQuotes(title) {
+		return title
+	}
+
 	offset := 0
 	removed := false
 	for offset < len(title) {
@@ -278,6 +350,29 @@ func stripLeadingProviderNoise(title string) string {
 		return title
 	}
 	return title[offset:]
+}
+
+func hasPairedOuterCourseTitleQuotes(title string) bool {
+	first, firstSize := utf8.DecodeRuneInString(title)
+	last, lastSize := utf8.DecodeLastRuneInString(title)
+	if firstSize == 0 || lastSize == 0 || len(title) <= firstSize+lastSize {
+		return false
+	}
+
+	switch first {
+	case '\'', '"':
+		return last == first
+	case '‘':
+		return last == '’'
+	case '“':
+		return last == '”'
+	case '„':
+		return last == '“' || last == '”'
+	case '«':
+		return last == '»'
+	default:
+		return false
+	}
 }
 
 func isCourseTitleQuote(r rune) bool {

--- a/internal/courses/title_normalization_test.go
+++ b/internal/courses/title_normalization_test.go
@@ -298,6 +298,72 @@ func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
 	}
 }
 
+func TestTitleNormalizerForceTokenOverridesOnlyHeuristicProtection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		rules   *TitleRules
+		changed bool
+	}{
+		{
+			name:  "uppercase force token with English suffix",
+			input: "English Klyuching guide",
+			want:  "Енглиш Ключинг гуиде",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuching": {}},
+			},
+			changed: true,
+		},
+		{
+			name:  "mixed case force token",
+			input: "English KlyuchMarker guide",
+			want:  "Енглиш Ключмаркер гуиде",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+			changed: true,
+		},
+		{
+			name:  "bracketed force token stays protected",
+			input: "English [Klyuching] guide",
+			want:  "English [Klyuching] guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuching": {}},
+			},
+		},
+		{
+			name:  "domain force token stays protected",
+			input: "English Klyuching.example guide",
+			want:  "English Klyuching.example guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuching": {}},
+			},
+		},
+		{
+			name:  "explicitly protected force token stays protected",
+			input: "English Klyuching guide",
+			want:  "English Klyuching guide",
+			rules: &TitleRules{
+				protectedSubstringsCI:  []string{"klyuch"},
+				forceNormalizeTokensCI: map[string]struct{}{"klyuching": {}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, changed := newTitleNormalizer(test.rules).Normalize(test.input)
+			if got != test.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", test.input, got, test.want)
+			}
+			if changed != test.changed {
+				t.Fatalf("Normalize(%q) changed = %t, want %t", test.input, changed, test.changed)
+			}
+		})
+	}
+}
+
 func TestTitleNormalizerStructuralCleanup(t *testing.T) {
 	rules := &TitleRules{
 		forceNormalizeTokensCI: map[string]struct{}{},

--- a/internal/courses/title_normalization_test.go
+++ b/internal/courses/title_normalization_test.go
@@ -207,10 +207,11 @@ func TestTitleNormalizerHasNoHardcodedForceRules(t *testing.T) {
 
 func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  string
-		rules *TitleRules
+		name    string
+		input   string
+		want    string
+		rules   *TitleRules
+		changed bool
 	}{
 		{
 			name:  "force token",
@@ -219,6 +220,7 @@ func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
 			rules: &TitleRules{
 				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
 			},
+			changed: true,
 		},
 		{
 			name:  "case insensitive force phrase",
@@ -228,6 +230,7 @@ func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
 				forceNormalizeTokensCI:  map[string]struct{}{},
 				forceNormalizePhrasesCI: []string{"novyiy stil"},
 			},
+			changed: true,
 		},
 		{
 			name:  "protected technical and network tokens",
@@ -235,6 +238,49 @@ func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
 			want:  "Неутрал ключмаркер C++ .NET 1C JavaScript React.js https://example.test/put [Provider Name] гуиде",
 			rules: &TitleRules{
 				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+			changed: true,
+		},
+		{
+			name:  "bracketed provider force token is ignored",
+			input: "English [klyuchmarker] guide",
+			want:  "English [klyuchmarker] guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+		},
+		{
+			name:  "URL force token is ignored",
+			input: "English https://example.test/?klyuchmarker guide",
+			want:  "English https://example.test/?klyuchmarker guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+		},
+		{
+			name:  "domain force token is ignored",
+			input: "English klyuchmarker.example guide",
+			want:  "English klyuchmarker.example guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+		},
+		{
+			name:  "bracketed provider force phrase is ignored",
+			input: "English [novyiy stil] guide",
+			want:  "English [novyiy stil] guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI:  map[string]struct{}{},
+				forceNormalizePhrasesCI: []string{"novyiy stil"},
+			},
+		},
+		{
+			name:  "force phrase with protected final token is ignored",
+			input: "English alpha PRO guide",
+			want:  "English alpha PRO guide",
+			rules: &TitleRules{
+				forceNormalizeTokensCI:  map[string]struct{}{},
+				forceNormalizePhrasesCI: []string{"alpha pro"},
 			},
 		},
 	}
@@ -245,8 +291,8 @@ func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
 			if got != test.want {
 				t.Fatalf("Normalize(%q) = %q, want %q", test.input, got, test.want)
 			}
-			if !changed {
-				t.Fatalf("Normalize(%q) changed = false, want true", test.input)
+			if changed != test.changed {
+				t.Fatalf("Normalize(%q) changed = %t, want %t", test.input, changed, test.changed)
 			}
 		})
 	}

--- a/internal/courses/title_normalization_test.go
+++ b/internal/courses/title_normalization_test.go
@@ -383,7 +383,19 @@ func TestTitleNormalizerStructuralCleanup(t *testing.T) {
 		{
 			name:    "entity filename noise and provider prefix",
 			input:   `"'9.[Provider]_Kurs&nbsp;dlya​ novichkov`,
-			want:    "[Provider] Курс для новичков",
+			want:    "[Provider] Курс\u00a0для новичков",
+			changed: true,
+		},
+		{
+			name:    "no underscore preserves exact whitespace",
+			input:   "Advanced  Go\tGuide\u00a0Notes",
+			want:    "Advanced  Go\tGuide\u00a0Notes",
+			changed: false,
+		},
+		{
+			name:    "underscore replacement preserves inter-field whitespace",
+			input:   "Alpha__Beta  Gamma\tDelta\u00a0Notes",
+			want:    "Alpha Beta  Gamma\tDelta\u00a0Notes",
 			changed: true,
 		},
 		{
@@ -432,6 +444,18 @@ func TestTitleNormalizerStructuralCleanup(t *testing.T) {
 			name:    "malformed entity unchanged",
 			input:   "Fish &bogus; Chips",
 			want:    "Fish &bogus; Chips",
+			changed: false,
+		},
+		{
+			name:    "format-only cleanup falls back to original",
+			input:   "\u200b",
+			want:    "\u200b",
+			changed: false,
+		},
+		{
+			name:    "separator-only cleanup falls back to original",
+			input:   "___",
+			want:    "___",
 			changed: false,
 		},
 		{

--- a/internal/courses/title_normalization_test.go
+++ b/internal/courses/title_normalization_test.go
@@ -393,6 +393,42 @@ func TestTitleNormalizerStructuralCleanup(t *testing.T) {
 			changed: true,
 		},
 		{
+			name:    "ordinary single underscores become spaces",
+			input:   "Alpha_Beta_Gamma",
+			want:    "Alpha Beta Gamma",
+			changed: true,
+		},
+		{
+			name:    "URL underscore stays intact",
+			input:   "https://example.test/my_course",
+			want:    "https://example.test/my_course",
+			changed: false,
+		},
+		{
+			name:    "email underscore stays intact",
+			input:   "Contact user_name@example.test today",
+			want:    "Contact user_name@example.test today",
+			changed: false,
+		},
+		{
+			name:    "domain underscore stays intact",
+			input:   "sub_domain.example",
+			want:    "sub_domain.example",
+			changed: false,
+		},
+		{
+			name:    "technical file identifier stays intact",
+			input:   "Open archive_5881340_RUS today",
+			want:    "Open archive_5881340_RUS today",
+			changed: false,
+		},
+		{
+			name:    "whole technical-looking slug is cleaned",
+			input:   "Archive_5881340_RUS",
+			want:    "Archive 5881340 RUS",
+			changed: true,
+		},
+		{
 			name:    "malformed entity unchanged",
 			input:   "Fish &bogus; Chips",
 			want:    "Fish &bogus; Chips",

--- a/internal/courses/title_normalization_test.go
+++ b/internal/courses/title_normalization_test.go
@@ -447,6 +447,30 @@ func TestTitleNormalizerStructuralCleanup(t *testing.T) {
 			changed: false,
 		},
 		{
+			name:    "semicolonless entity-like URL query remains exact",
+			input:   "https://example.test/?asset=1&copy=2",
+			want:    "https://example.test/?asset=1&copy=2",
+			changed: false,
+		},
+		{
+			name:    "strict named entity is decoded",
+			input:   "Alpha &amp; Beta",
+			want:    "Alpha & Beta",
+			changed: true,
+		},
+		{
+			name:    "strict decimal numeric entity is decoded",
+			input:   "Alpha &#169; Beta",
+			want:    "Alpha © Beta",
+			changed: true,
+		},
+		{
+			name:    "strict hexadecimal numeric entity is decoded",
+			input:   "Alpha &#xA9; Beta",
+			want:    "Alpha © Beta",
+			changed: true,
+		},
+		{
 			name:    "format-only cleanup falls back to original",
 			input:   "\u200b",
 			want:    "\u200b",
@@ -462,6 +486,18 @@ func TestTitleNormalizerStructuralCleanup(t *testing.T) {
 			name:    "stray quote without bracketed provider stays",
 			input:   `'English guide`,
 			want:    `'English guide`,
+			changed: false,
+		},
+		{
+			name:    "paired outer quotes around provider title stay balanced",
+			input:   `"[Provider] Course"`,
+			want:    `"[Provider] Course"`,
+			changed: false,
+		},
+		{
+			name:    "paired curly outer quotes around provider title stay balanced",
+			input:   `“[Provider] Course”`,
+			want:    `“[Provider] Course”`,
 			changed: false,
 		},
 		{

--- a/internal/courses/title_normalization_test.go
+++ b/internal/courses/title_normalization_test.go
@@ -1,6 +1,9 @@
 package courses
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTitleNormalizerTransliteratesGenericTitles(t *testing.T) {
 	tests := []struct {
@@ -89,6 +92,7 @@ func TestTitleNormalizerUsesLoadedProtectionRules(t *testing.T) {
 		protectedSubstringsCI: []string{
 			"academy",
 		},
+		forceNormalizeTokensCI: map[string]struct{}{},
 	}
 	tests := []struct {
 		name  string
@@ -193,7 +197,71 @@ func TestTitleNormalizerProtectsNonTransliterationTokens(t *testing.T) {
 	}
 }
 
-func TestTitleNormalizerReviewRegressions(t *testing.T) {
+func TestTitleNormalizerHasNoHardcodedForceRules(t *testing.T) {
+	input := "Neutral klyuchmarker guide"
+	got, changed := newTitleNormalizer(nil).Normalize(input)
+	if got != input || changed {
+		t.Fatalf("Normalize(%q) = (%q, %t), want unchanged without private rules", input, got, changed)
+	}
+}
+
+func TestTitleNormalizerForceRulesNormalizeWholeTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		rules *TitleRules
+	}{
+		{
+			name:  "force token",
+			input: "Neutral klyuchmarker guide",
+			want:  "Неутрал ключмаркер гуиде",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+		},
+		{
+			name:  "case insensitive force phrase",
+			input: "Neutral Novyiy stil guide",
+			want:  "Неутрал Новый стил гуиде",
+			rules: &TitleRules{
+				forceNormalizeTokensCI:  map[string]struct{}{},
+				forceNormalizePhrasesCI: []string{"novyiy stil"},
+			},
+		},
+		{
+			name:  "protected technical and network tokens",
+			input: "Neutral klyuchmarker C++ .NET 1C JavaScript React.js https://example.test/put [Provider Name] guide",
+			want:  "Неутрал ключмаркер C++ .NET 1C JavaScript React.js https://example.test/put [Provider Name] гуиде",
+			rules: &TitleRules{
+				forceNormalizeTokensCI: map[string]struct{}{"klyuchmarker": {}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, changed := newTitleNormalizer(test.rules).Normalize(test.input)
+			if got != test.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", test.input, got, test.want)
+			}
+			if !changed {
+				t.Fatalf("Normalize(%q) changed = false, want true", test.input)
+			}
+		})
+	}
+}
+
+func TestTitleNormalizerStructuralCleanup(t *testing.T) {
+	rules := &TitleRules{
+		forceNormalizeTokensCI: map[string]struct{}{},
+		structuralCleanup: titleStructuralCleanup{
+			decodeHTMLEntities:        true,
+			dropZeroWidthFormatChars:  true,
+			underscoresAsSpaces:       true,
+			stripLeadingProviderNoise: true,
+		},
+	}
 	tests := []struct {
 		name    string
 		input   string
@@ -201,17 +269,87 @@ func TestTitleNormalizerReviewRegressions(t *testing.T) {
 		changed bool
 	}{
 		{
-			name:    "forced transliteration leaves English context alone",
-			input:   "English freymvork guide",
-			want:    "English фреймворк guide",
+			name:    "entity filename noise and provider prefix",
+			input:   `"'9.[Provider]_Kurs&nbsp;dlya​ novichkov`,
+			want:    "[Provider] Курс для новичков",
 			changed: true,
 		},
 		{
-			name:    "forced c number do leaves English context alone",
-			input:   "English c 0 do guide",
-			want:    "English с 0 до guide",
+			name:    "cleanup only counts as change",
+			input:   "Alpha__Beta",
+			want:    "Alpha Beta",
 			changed: true,
 		},
+		{
+			name:    "malformed entity unchanged",
+			input:   "Fish &bogus; Chips",
+			want:    "Fish &bogus; Chips",
+			changed: false,
+		},
+		{
+			name:    "stray quote without bracketed provider stays",
+			input:   `'English guide`,
+			want:    `'English guide`,
+			changed: false,
+		},
+		{
+			name:    "ordinal without bracketed provider stays",
+			input:   "12.English guide",
+			want:    "12.English guide",
+			changed: false,
+		},
+	}
+
+	normalizer := newTitleNormalizer(rules)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, changed := normalizer.Normalize(test.input)
+			if got != test.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", test.input, got, test.want)
+			}
+			if changed != test.changed {
+				t.Fatalf("Normalize(%q) changed = %t, want %t", test.input, changed, test.changed)
+			}
+		})
+	}
+}
+
+func TestTitleNormalizerIsIdempotent(t *testing.T) {
+	rules, err := LoadTitleRules(strings.NewReader(`{
+		"schema_version": "title-normalization-rules/v2",
+		"protected_tokens_ci": [],
+		"protected_tokens_exact": [],
+		"protected_substrings_ci": [],
+		"force_normalize_tokens_ci": ["klyuchmarker"],
+		"force_normalize_phrases_ci": [],
+		"structural_cleanup": {
+			"decode_html_entities": true,
+			"drop_zero_width_format_chars": true,
+			"underscores_as_spaces": true,
+			"strip_leading_provider_noise": true
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+	normalizer := newTitleNormalizer(rules)
+	first, changed := normalizer.Normalize(`7.[Provider]_Kurs dlya klyuchmarker`)
+	if !changed {
+		t.Fatal("first Normalize() changed = false, want true")
+	}
+	second, changed := normalizer.Normalize(first)
+	if second != first || changed {
+		t.Fatalf("second Normalize() = (%q, %t), want (%q, false)", second, changed, first)
+	}
+}
+
+func TestTitleNormalizerReviewRegressions(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		changed bool
+	}{
 		{
 			name:  "marker scoring uses longest non-overlapping occurrences",
 			input: "Maya Bay Kayak",

--- a/internal/courses/title_rules.go
+++ b/internal/courses/title_rules.go
@@ -136,6 +136,11 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 	if err := addCIRules("force_normalize_tokens_ci", file.ForceNormalizeTokensCI, rules.forceNormalizeTokensCI); err != nil {
 		return nil, err
 	}
+	for _, value := range file.ForceNormalizeTokensCI {
+		if !isSingleCourseTitleWord(value) {
+			return nil, fmt.Errorf("decode title rules: force_normalize_tokens_ci value %q must be exactly one title word", value)
+		}
+	}
 	phrases := make(map[string]struct{}, len(file.ForceNormalizePhrasesCI))
 	for _, value := range file.ForceNormalizePhrasesCI {
 		normalized, err := normalizeTitleRuleValue("force_normalize_phrases_ci", value)
@@ -165,6 +170,17 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 	}
 
 	return rules, nil
+}
+
+func isSingleCourseTitleWord(value string) bool {
+	for offset := 0; offset < len(value); {
+		if !isCourseTitleWordRuneAt(value, offset) {
+			return false
+		}
+		_, size := utf8.DecodeRuneInString(value[offset:])
+		offset += size
+	}
+	return value != ""
 }
 
 func rejectDuplicateTopLevelKeys(data []byte) error {

--- a/internal/courses/title_rules.go
+++ b/internal/courses/title_rules.go
@@ -140,6 +140,12 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 		if !isSingleCourseTitleWord(value) {
 			return nil, fmt.Errorf("decode title rules: force_normalize_tokens_ci value %q must be exactly one title word", value)
 		}
+		if isInherentlyHardProtectedTitleRuleWord(value) {
+			return nil, fmt.Errorf("decode title rules: force_normalize_tokens_ci value %q cannot match a protected title field", value)
+		}
+		if titleRuleWordIsExplicitlyProtected(rules, value) {
+			return nil, fmt.Errorf("decode title rules: force_normalize_tokens_ci value %q is shadowed by a protected title rule", value)
+		}
 	}
 	phrases := make(map[string]struct{}, len(file.ForceNormalizePhrasesCI))
 	for _, value := range file.ForceNormalizePhrasesCI {
@@ -151,6 +157,17 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 		if len(words) < 2 {
 			return nil, fmt.Errorf("decode title rules: force_normalize_phrases_ci value %q must contain at least two words", value)
 		}
+		for _, word := range words {
+			if !isSingleCourseTitleWord(word) {
+				return nil, fmt.Errorf("decode title rules: force_normalize_phrases_ci value %q contains invalid word %q", value, word)
+			}
+			if isInherentlyHardProtectedTitleRuleWord(word) {
+				return nil, fmt.Errorf("decode title rules: force_normalize_phrases_ci value %q contains protected word %q", value, word)
+			}
+			if titleRuleWordIsExplicitlyProtected(rules, word) {
+				return nil, fmt.Errorf("decode title rules: force_normalize_phrases_ci value %q is shadowed by protected word %q", value, word)
+			}
+		}
 		lower := strings.ToLower(strings.Join(words, " "))
 		if _, exists := phrases[lower]; exists {
 			return nil, fmt.Errorf("decode title rules: duplicate force_normalize_phrases_ci value %q", value)
@@ -158,17 +175,6 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 		phrases[lower] = struct{}{}
 		rules.forceNormalizePhrasesCI = append(rules.forceNormalizePhrasesCI, lower)
 	}
-	for token := range rules.forceNormalizeTokensCI {
-		if _, exists := rules.protectedTokensCI[token]; exists {
-			return nil, fmt.Errorf("decode title rules: token %q appears in both protected and forced sets", token)
-		}
-		for exact := range rules.protectedTokensExact {
-			if strings.EqualFold(token, exact) {
-				return nil, fmt.Errorf("decode title rules: token %q appears in both protected and forced sets", token)
-			}
-		}
-	}
-
 	return rules, nil
 }
 
@@ -181,6 +187,28 @@ func isSingleCourseTitleWord(value string) bool {
 		offset += size
 	}
 	return value != ""
+}
+
+func isInherentlyHardProtectedTitleRuleWord(value string) bool {
+	return strings.ContainsAny(value, "0123456789_@/:")
+}
+
+func titleRuleWordIsExplicitlyProtected(rules *TitleRules, value string) bool {
+	lower := strings.ToLower(value)
+	if _, protected := rules.protectedTokensCI[lower]; protected {
+		return true
+	}
+	for exact := range rules.protectedTokensExact {
+		if strings.EqualFold(value, exact) {
+			return true
+		}
+	}
+	for _, substring := range rules.protectedSubstringsCI {
+		if strings.Contains(lower, substring) {
+			return true
+		}
+	}
+	return false
 }
 
 func rejectDuplicateTopLevelKeys(data []byte) error {

--- a/internal/courses/title_rules.go
+++ b/internal/courses/title_rules.go
@@ -9,19 +9,39 @@ import (
 	"unicode/utf8"
 )
 
-const titleRulesSchema = "title-normalization-rules/v1"
+const titleRulesSchema = "title-normalization-rules/v2"
 
 type TitleRules struct {
-	protectedTokensCI     map[string]struct{}
-	protectedTokensExact  map[string]struct{}
-	protectedSubstringsCI []string
+	protectedTokensCI       map[string]struct{}
+	protectedTokensExact    map[string]struct{}
+	protectedSubstringsCI   []string
+	forceNormalizeTokensCI  map[string]struct{}
+	forceNormalizePhrasesCI []string
+	structuralCleanup       titleStructuralCleanup
 }
 
 type titleRulesFile struct {
-	SchemaVersion         string   `json:"schema_version"`
-	ProtectedTokensCI     []string `json:"protected_tokens_ci"`
-	ProtectedTokensExact  []string `json:"protected_tokens_exact"`
-	ProtectedSubstringsCI []string `json:"protected_substrings_ci"`
+	SchemaVersion           string          `json:"schema_version"`
+	ProtectedTokensCI       []string        `json:"protected_tokens_ci"`
+	ProtectedTokensExact    []string        `json:"protected_tokens_exact"`
+	ProtectedSubstringsCI   []string        `json:"protected_substrings_ci"`
+	ForceNormalizeTokensCI  []string        `json:"force_normalize_tokens_ci"`
+	ForceNormalizePhrasesCI []string        `json:"force_normalize_phrases_ci"`
+	StructuralCleanup       json.RawMessage `json:"structural_cleanup"`
+}
+
+type titleStructuralCleanup struct {
+	decodeHTMLEntities        bool
+	dropZeroWidthFormatChars  bool
+	underscoresAsSpaces       bool
+	stripLeadingProviderNoise bool
+}
+
+type titleStructuralCleanupFile struct {
+	DecodeHTMLEntities        *bool `json:"decode_html_entities"`
+	DropZeroWidthFormatChars  *bool `json:"drop_zero_width_format_chars"`
+	UnderscoresAsSpaces       *bool `json:"underscores_as_spaces"`
+	StripLeadingProviderNoise *bool `json:"strip_leading_provider_noise"`
 }
 
 func LoadTitleRules(r io.Reader) (*TitleRules, error) {
@@ -54,14 +74,40 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 	}
 	if file.ProtectedTokensCI == nil ||
 		file.ProtectedTokensExact == nil ||
-		file.ProtectedSubstringsCI == nil {
+		file.ProtectedSubstringsCI == nil ||
+		file.ForceNormalizeTokensCI == nil ||
+		file.ForceNormalizePhrasesCI == nil {
 		return nil, fmt.Errorf("decode title rules: all rule arrays are required")
+	}
+	if len(file.StructuralCleanup) == 0 {
+		return nil, fmt.Errorf("decode title rules: structural_cleanup is required")
+	}
+	if err := rejectDuplicateTopLevelKeys(file.StructuralCleanup); err != nil {
+		return nil, fmt.Errorf("decode title rules: structural_cleanup: %w", err)
+	}
+	var cleanupFile titleStructuralCleanupFile
+	if err := decodeSingleJSONValue(file.StructuralCleanup, &cleanupFile); err != nil {
+		return nil, fmt.Errorf("decode title rules: structural_cleanup: %w", err)
+	}
+	if cleanupFile.DecodeHTMLEntities == nil ||
+		cleanupFile.DropZeroWidthFormatChars == nil ||
+		cleanupFile.UnderscoresAsSpaces == nil ||
+		cleanupFile.StripLeadingProviderNoise == nil {
+		return nil, fmt.Errorf("decode title rules: all structural_cleanup booleans are required")
 	}
 
 	rules := &TitleRules{
-		protectedTokensCI:     make(map[string]struct{}, len(file.ProtectedTokensCI)),
-		protectedTokensExact:  make(map[string]struct{}, len(file.ProtectedTokensExact)),
-		protectedSubstringsCI: make([]string, 0, len(file.ProtectedSubstringsCI)),
+		protectedTokensCI:       make(map[string]struct{}, len(file.ProtectedTokensCI)),
+		protectedTokensExact:    make(map[string]struct{}, len(file.ProtectedTokensExact)),
+		protectedSubstringsCI:   make([]string, 0, len(file.ProtectedSubstringsCI)),
+		forceNormalizeTokensCI:  make(map[string]struct{}, len(file.ForceNormalizeTokensCI)),
+		forceNormalizePhrasesCI: make([]string, 0, len(file.ForceNormalizePhrasesCI)),
+		structuralCleanup: titleStructuralCleanup{
+			decodeHTMLEntities:        *cleanupFile.DecodeHTMLEntities,
+			dropZeroWidthFormatChars:  *cleanupFile.DropZeroWidthFormatChars,
+			underscoresAsSpaces:       *cleanupFile.UnderscoresAsSpaces,
+			stripLeadingProviderNoise: *cleanupFile.StripLeadingProviderNoise,
+		},
 	}
 	if err := addCIRules("protected_tokens_ci", file.ProtectedTokensCI, rules.protectedTokensCI); err != nil {
 		return nil, err
@@ -85,6 +131,36 @@ func LoadTitleRules(r io.Reader) (*TitleRules, error) {
 	for _, exact := range file.ProtectedTokensExact {
 		if _, exists := rules.protectedTokensCI[strings.ToLower(exact)]; exists {
 			return nil, fmt.Errorf("decode title rules: protected token %q appears in both exact and case-insensitive sets", exact)
+		}
+	}
+	if err := addCIRules("force_normalize_tokens_ci", file.ForceNormalizeTokensCI, rules.forceNormalizeTokensCI); err != nil {
+		return nil, err
+	}
+	phrases := make(map[string]struct{}, len(file.ForceNormalizePhrasesCI))
+	for _, value := range file.ForceNormalizePhrasesCI {
+		normalized, err := normalizeTitleRuleValue("force_normalize_phrases_ci", value)
+		if err != nil {
+			return nil, err
+		}
+		words := strings.Fields(normalized)
+		if len(words) < 2 {
+			return nil, fmt.Errorf("decode title rules: force_normalize_phrases_ci value %q must contain at least two words", value)
+		}
+		lower := strings.ToLower(strings.Join(words, " "))
+		if _, exists := phrases[lower]; exists {
+			return nil, fmt.Errorf("decode title rules: duplicate force_normalize_phrases_ci value %q", value)
+		}
+		phrases[lower] = struct{}{}
+		rules.forceNormalizePhrasesCI = append(rules.forceNormalizePhrasesCI, lower)
+	}
+	for token := range rules.forceNormalizeTokensCI {
+		if _, exists := rules.protectedTokensCI[token]; exists {
+			return nil, fmt.Errorf("decode title rules: token %q appears in both protected and forced sets", token)
+		}
+		for exact := range rules.protectedTokensExact {
+			if strings.EqualFold(token, exact) {
+				return nil, fmt.Errorf("decode title rules: token %q appears in both protected and forced sets", token)
+			}
 		}
 	}
 
@@ -136,15 +212,21 @@ func cloneTitleRules(rules *TitleRules) *TitleRules {
 		return nil
 	}
 	clone := &TitleRules{
-		protectedTokensCI:     make(map[string]struct{}, len(rules.protectedTokensCI)),
-		protectedTokensExact:  make(map[string]struct{}, len(rules.protectedTokensExact)),
-		protectedSubstringsCI: append([]string(nil), rules.protectedSubstringsCI...),
+		protectedTokensCI:       make(map[string]struct{}, len(rules.protectedTokensCI)),
+		protectedTokensExact:    make(map[string]struct{}, len(rules.protectedTokensExact)),
+		protectedSubstringsCI:   append([]string(nil), rules.protectedSubstringsCI...),
+		forceNormalizeTokensCI:  make(map[string]struct{}, len(rules.forceNormalizeTokensCI)),
+		forceNormalizePhrasesCI: append([]string(nil), rules.forceNormalizePhrasesCI...),
+		structuralCleanup:       rules.structuralCleanup,
 	}
 	for token := range rules.protectedTokensCI {
 		clone.protectedTokensCI[token] = struct{}{}
 	}
 	for token := range rules.protectedTokensExact {
 		clone.protectedTokensExact[token] = struct{}{}
+	}
+	for token := range rules.forceNormalizeTokensCI {
+		clone.forceNormalizeTokensCI[token] = struct{}{}
 	}
 	return clone
 }

--- a/internal/courses/title_rules_test.go
+++ b/internal/courses/title_rules_test.go
@@ -5,12 +5,20 @@ import (
 	"testing"
 )
 
-func TestLoadTitleRulesAcceptsStrictRulesFile(t *testing.T) {
+func TestLoadTitleRulesAcceptsStrictV2RulesFile(t *testing.T) {
 	rules, err := LoadTitleRules(strings.NewReader(`{
-		"schema_version": "title-normalization-rules/v1",
+		"schema_version": "title-normalization-rules/v2",
 		"protected_tokens_ci": ["nimbus"],
 		"protected_tokens_exact": ["Vector"],
-		"protected_substrings_ci": ["academy"]
+		"protected_substrings_ci": ["academy"],
+		"force_normalize_tokens_ci": ["klyuchmarker"],
+		"force_normalize_phrases_ci": ["novyiy stil"],
+		"structural_cleanup": {
+			"decode_html_entities": true,
+			"drop_zero_width_format_chars": true,
+			"underscores_as_spaces": true,
+			"strip_leading_provider_noise": true
+		}
 	}`))
 	if err != nil {
 		t.Fatalf("LoadTitleRules() error = %v", err)
@@ -24,94 +32,222 @@ func TestLoadTitleRulesAcceptsStrictRulesFile(t *testing.T) {
 	if got := strings.Join(rules.protectedSubstringsCI, ","); got != "academy" {
 		t.Fatalf("protectedSubstringsCI = %q, want academy", got)
 	}
+	if _, ok := rules.forceNormalizeTokensCI["klyuchmarker"]; !ok {
+		t.Fatal("forceNormalizeTokensCI missing klyuchmarker")
+	}
+	if got := strings.Join(rules.forceNormalizePhrasesCI, ","); got != "novyiy stil" {
+		t.Fatalf("forceNormalizePhrasesCI = %q, want novyiy stil", got)
+	}
+	if !rules.structuralCleanup.decodeHTMLEntities ||
+		!rules.structuralCleanup.dropZeroWidthFormatChars ||
+		!rules.structuralCleanup.underscoresAsSpaces ||
+		!rules.structuralCleanup.stripLeadingProviderNoise {
+		t.Fatalf("structuralCleanup = %+v, want all enabled", rules.structuralCleanup)
+	}
 }
 
-func TestLoadTitleRulesRejectsInvalidFiles(t *testing.T) {
+func TestLoadTitleRulesRejectsInvalidV2Files(t *testing.T) {
 	tests := []struct {
 		name string
 		json string
 	}{
 		{
-			name: "wrong schema",
-			json: `{
-				"schema_version": "title-normalization-rules/v2",
-				"protected_tokens_ci": [],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "unknown field",
+			name: "v1 schema",
 			json: `{
 				"schema_version": "title-normalization-rules/v1",
 				"protected_tokens_ci": [],
 				"protected_tokens_exact": [],
 				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`,
+		},
+		{
+			name: "unknown top-level field",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				},
 				"extra": []
+			}`,
+		},
+		{
+			name: "missing force token array",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`,
+		},
+		{
+			name: "missing protection array",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`,
+		},
+		{
+			name: "missing structural cleanup",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": []
+			}`,
+		},
+		{
+			name: "missing structural cleanup boolean",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false
+				}
+			}`,
+		},
+		{
+			name: "unknown structural cleanup field",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false,
+					"extra": false
+				}
+			}`,
+		},
+		{
+			name: "duplicate structural cleanup field",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"decode_html_entities": true,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`,
+		},
+		{
+			name: "duplicate force token",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": ["klyuch", "Klyuch"],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`,
+		},
+		{
+			name: "duplicate force phrase",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": ["novyiy stil", "NOVYIY STIL"],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`,
+		},
+		{
+			name: "protected and forced token overlap",
+			json: `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": ["klyuch"],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": ["KLYUCH"],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
 			}`,
 		},
 		{
 			name: "trailing json value",
 			json: `{
-				"schema_version": "title-normalization-rules/v1",
+				"schema_version": "title-normalization-rules/v2",
 				"protected_tokens_ci": [],
 				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
 			}{}`,
-		},
-		{
-			name: "empty value",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [""],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "untrimmed value",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [" nimbus"],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "case insensitive duplicate",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": ["nimbus", "Nimbus"],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "exact duplicate",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [],
-				"protected_tokens_exact": ["Vector", "Vector"],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "substring duplicate",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": ["academy", "Academy"]
-			}`,
-		},
-		{
-			name: "contradictory ci exact token overlap",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": ["nimbus"],
-				"protected_tokens_exact": ["Nimbus"],
-				"protected_substrings_ci": []
-			}`,
 		},
 	}
 
@@ -125,67 +261,88 @@ func TestLoadTitleRulesRejectsInvalidFiles(t *testing.T) {
 }
 
 func TestLoadTitleRulesRejectsDuplicateTopLevelKeys(t *testing.T) {
+	_, err := LoadTitleRules(strings.NewReader(`{
+		"schema_version": "title-normalization-rules/v2",
+		"schema_version": "title-normalization-rules/v2",
+		"protected_tokens_ci": [],
+		"protected_tokens_exact": [],
+		"protected_substrings_ci": [],
+		"force_normalize_tokens_ci": [],
+		"force_normalize_phrases_ci": [],
+		"structural_cleanup": {
+			"decode_html_entities": false,
+			"drop_zero_width_format_chars": false,
+			"underscores_as_spaces": false,
+			"strip_leading_provider_noise": false
+		}
+	}`))
+	if err == nil {
+		t.Fatal("LoadTitleRules() error = nil, want duplicate key error")
+	}
+	if got := err.Error(); !strings.Contains(got, "decode title rules") || strings.Contains(got, "link tombstones") {
+		t.Fatalf("LoadTitleRules() error = %q, want title rules context only", got)
+	}
+}
+
+func TestLoadTitleRulesRejectsInvalidRuleValues(t *testing.T) {
 	tests := []struct {
-		name string
-		json string
+		name  string
+		field string
+		value string
 	}{
-		{
-			name: "schema version",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "case insensitive tokens",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": ["nimbus"],
-				"protected_tokens_ci": ["vector"],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "exact tokens",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [],
-				"protected_tokens_exact": ["Vector"],
-				"protected_tokens_exact": ["Nimbus"],
-				"protected_substrings_ci": []
-			}`,
-		},
-		{
-			name: "case insensitive substrings",
-			json: `{
-				"schema_version": "title-normalization-rules/v1",
-				"protected_tokens_ci": [],
-				"protected_tokens_exact": [],
-				"protected_substrings_ci": ["academy"],
-				"protected_substrings_ci": ["studio"]
-			}`,
-		},
+		{name: "empty value", field: "protected_tokens_ci", value: `[""]`},
+		{name: "untrimmed value", field: "protected_tokens_ci", value: `[" nimbus"]`},
+		{name: "case insensitive duplicate", field: "protected_tokens_ci", value: `["nimbus","Nimbus"]`},
+		{name: "exact duplicate", field: "protected_tokens_exact", value: `["Vector","Vector"]`},
+		{name: "substring duplicate", field: "protected_substrings_ci", value: `["academy","Academy"]`},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := LoadTitleRules(strings.NewReader(test.json))
-			if err == nil {
-				t.Fatal("LoadTitleRules() error = nil, want duplicate key error")
-			}
-			if got := err.Error(); !strings.Contains(got, "decode title rules") || strings.Contains(got, "link tombstones") {
-				t.Fatalf("LoadTitleRules() error = %q, want title rules context only", got)
+			payload := `{
+				"schema_version": "title-normalization-rules/v2",
+				"protected_tokens_ci": [],
+				"protected_tokens_exact": [],
+				"protected_substrings_ci": [],
+				"force_normalize_tokens_ci": [],
+				"force_normalize_phrases_ci": [],
+				"structural_cleanup": {
+					"decode_html_entities": false,
+					"drop_zero_width_format_chars": false,
+					"underscores_as_spaces": false,
+					"strip_leading_provider_noise": false
+				}
+			}`
+			payload = strings.Replace(payload, `"`+test.field+`": []`, `"`+test.field+`": `+test.value, 1)
+			if _, err := LoadTitleRules(strings.NewReader(payload)); err == nil {
+				t.Fatal("LoadTitleRules() error = nil, want error")
 			}
 		})
 	}
 }
 
+func TestLoadTitleRulesRejectsProtectedTokenOverlap(t *testing.T) {
+	_, err := LoadTitleRules(strings.NewReader(`{
+		"schema_version": "title-normalization-rules/v2",
+		"protected_tokens_ci": ["nimbus"],
+		"protected_tokens_exact": ["Nimbus"],
+		"protected_substrings_ci": [],
+		"force_normalize_tokens_ci": [],
+		"force_normalize_phrases_ci": [],
+		"structural_cleanup": {
+			"decode_html_entities": false,
+			"drop_zero_width_format_chars": false,
+			"underscores_as_spaces": false,
+			"strip_leading_provider_noise": false
+		}
+	}`))
+	if err == nil {
+		t.Fatal("LoadTitleRules() error = nil, want overlap error")
+	}
+}
+
 func TestLoadTitleRulesRejectsInvalidUTF8(t *testing.T) {
-	if _, err := LoadTitleRules(strings.NewReader("{\"schema_version\":\"title-normalization-rules/v1\",\"protected_tokens_ci\":[\"\xff\"],\"protected_tokens_exact\":[],\"protected_substrings_ci\":[]}")); err == nil {
+	if _, err := LoadTitleRules(strings.NewReader("{\"schema_version\":\"title-normalization-rules/v2\",\"protected_tokens_ci\":[\"\xff\"],\"protected_tokens_exact\":[],\"protected_substrings_ci\":[],\"force_normalize_tokens_ci\":[],\"force_normalize_phrases_ci\":[],\"structural_cleanup\":{\"decode_html_entities\":false,\"drop_zero_width_format_chars\":false,\"underscores_as_spaces\":false,\"strip_leading_provider_noise\":false}}")); err == nil {
 		t.Fatal("LoadTitleRules() error = nil, want error")
 	}
 }

--- a/internal/courses/title_rules_test.go
+++ b/internal/courses/title_rules_test.go
@@ -297,6 +297,9 @@ func TestLoadTitleRulesRejectsInvalidRuleValues(t *testing.T) {
 		{name: "substring duplicate", field: "protected_substrings_ci", value: `["academy","Academy"]`},
 		{name: "multiword force token", field: "force_normalize_tokens_ci", value: `["novyiy stil"]`},
 		{name: "punctuation-split force token", field: "force_normalize_tokens_ci", value: `["alpha-beta"]`},
+		{name: "hard-protected force token", field: "force_normalize_tokens_ci", value: `["alpha_2024"]`},
+		{name: "punctuation-split force phrase component", field: "force_normalize_phrases_ci", value: `["alpha-beta guide"]`},
+		{name: "hard-protected force phrase component", field: "force_normalize_phrases_ci", value: `["alpha 2024"]`},
 	}
 
 	for _, test := range tests {
@@ -321,6 +324,90 @@ func TestLoadTitleRulesRejectsInvalidRuleValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadTitleRulesRejectsShadowedForceRules(t *testing.T) {
+	tests := []struct {
+		name               string
+		protectedTokensCI  string
+		protectedExact     string
+		protectedSubstring string
+		forceTokens        string
+		forcePhrases       string
+	}{
+		{
+			name:               "force token shadowed by case insensitive token",
+			protectedTokensCI:  `["klyuchmarker"]`,
+			protectedExact:     `[]`,
+			protectedSubstring: `[]`,
+			forceTokens:        `["klyuchmarker"]`,
+			forcePhrases:       `[]`,
+		},
+		{
+			name:               "force token shadowed by substring",
+			protectedTokensCI:  `[]`,
+			protectedExact:     `[]`,
+			protectedSubstring: `["klyuch"]`,
+			forceTokens:        `["klyuchmarker"]`,
+			forcePhrases:       `[]`,
+		},
+		{
+			name:               "force phrase shadowed by exact token",
+			protectedTokensCI:  `[]`,
+			protectedExact:     `["Beta"]`,
+			protectedSubstring: `[]`,
+			forceTokens:        `[]`,
+			forcePhrases:       `["alpha beta"]`,
+		},
+		{
+			name:               "force phrase shadowed by case insensitive token",
+			protectedTokensCI:  `["alpha"]`,
+			protectedExact:     `[]`,
+			protectedSubstring: `[]`,
+			forceTokens:        `[]`,
+			forcePhrases:       `["alpha beta"]`,
+		},
+		{
+			name:               "force phrase shadowed by substring",
+			protectedTokensCI:  `[]`,
+			protectedExact:     `[]`,
+			protectedSubstring: `["bet"]`,
+			forceTokens:        `[]`,
+			forcePhrases:       `["alpha beta"]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload := titleRulesTestPayload(
+				test.protectedTokensCI,
+				test.protectedExact,
+				test.protectedSubstring,
+				test.forceTokens,
+				test.forcePhrases,
+			)
+			if _, err := LoadTitleRules(strings.NewReader(payload)); err == nil {
+				t.Fatal("LoadTitleRules() error = nil, want shadowed rule error")
+			}
+		})
+	}
+}
+
+func titleRulesTestPayload(protectedCI, protectedExact, protectedSubstrings, forceTokens, forcePhrases string) string {
+	return `{
+		"schema_version": "title-normalization-rules/v2",
+		"protected_tokens_ci": ` + protectedCI + `,
+		"protected_tokens_exact": ` + protectedExact + `,
+		"protected_substrings_ci": ` + protectedSubstrings + `,
+		"force_normalize_tokens_ci": ` + forceTokens + `,
+		"force_normalize_phrases_ci": ` + forcePhrases + `,
+		"structural_cleanup": {
+			"decode_html_entities": false,
+			"drop_zero_width_format_chars": false,
+			"underscores_as_spaces": false,
+			"strip_leading_provider_noise": false
+		}
+	}`
 }
 
 func TestLoadTitleRulesRejectsProtectedTokenOverlap(t *testing.T) {

--- a/internal/courses/title_rules_test.go
+++ b/internal/courses/title_rules_test.go
@@ -295,6 +295,8 @@ func TestLoadTitleRulesRejectsInvalidRuleValues(t *testing.T) {
 		{name: "case insensitive duplicate", field: "protected_tokens_ci", value: `["nimbus","Nimbus"]`},
 		{name: "exact duplicate", field: "protected_tokens_exact", value: `["Vector","Vector"]`},
 		{name: "substring duplicate", field: "protected_substrings_ci", value: `["academy","Academy"]`},
+		{name: "multiword force token", field: "force_normalize_tokens_ci", value: `["novyiy stil"]`},
+		{name: "punctuation-split force token", field: "force_normalize_tokens_ci", value: `["alpha-beta"]`},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- replace the title-normalization rule file with a strict v2 schema
- support data-supplied whole-title force tokens and phrases while preserving protected technical and network tokens
- add opt-in structural cleanup for HTML entities, Unicode format characters, filename separators, and bracketed-provider prefixes
- remove catalog-specific forced transliteration from application code
- preserve source titles and stable catalog identities for cleanup-only changes

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `git ls-files '*.go' | xargs gopls check`
- `node --test tests/*.test.js`
- JavaScript syntax checks
