### PR TITLE
Bound status-only link audit fallback

### DIFF
--- a/internal/courses/link_audit_client.go
+++ b/internal/courses/link_audit_client.go
@@ -342,21 +342,30 @@ func requestLinkAuditObservation(ctx context.Context, candidate linkAuditCandida
 	}()
 
 	status := head.StatusCode
-	if status == http.StatusMethodNotAllowed || status == http.StatusNotImplemented || (status >= 200 && status <= 299 && ruleNeedsLinkAuditBody(policy.matchingRule(candidate.host))) {
-		if status == http.StatusMethodNotAllowed || status == http.StatusNotImplemented || status >= 200 && status <= 299 {
-			get, err := doLinkAuditRequest(ctx, client, http.MethodGet, candidate.rawURL, policy.MaxBodyBytes)
-			if err != nil {
-				return LinkAuditObservation{}, err
-			}
-			defer func() {
-				_ = get.Body.Close()
-			}()
-			body, err := io.ReadAll(io.LimitReader(get.Body, policy.MaxBodyBytes))
-			if err != nil {
-				return LinkAuditObservation{}, err
-			}
-			return LinkAuditObservation{HTTPStatus: get.StatusCode, Body: body}, nil
+	needsBody := ruleNeedsLinkAuditBody(policy.matchingRule(candidate.host))
+	if status == http.StatusMethodNotAllowed || status == http.StatusNotImplemented || (status >= 200 && status <= 299 && needsBody) {
+		bodyLimit := int64(1)
+		if needsBody {
+			bodyLimit = policy.MaxBodyBytes
 		}
+		get, err := doLinkAuditRequest(ctx, client, http.MethodGet, candidate.rawURL, bodyLimit)
+		if err != nil {
+			return LinkAuditObservation{}, err
+		}
+		defer func() {
+			_ = get.Body.Close()
+		}()
+		if !needsBody {
+			return LinkAuditObservation{HTTPStatus: get.StatusCode}, nil
+		}
+		body, err := io.ReadAll(io.LimitReader(get.Body, bodyLimit+1))
+		if err != nil {
+			return LinkAuditObservation{}, err
+		}
+		if int64(len(body)) > bodyLimit {
+			body = body[:bodyLimit]
+		}
+		return LinkAuditObservation{HTTPStatus: get.StatusCode, Body: body}, nil
 	}
 	return LinkAuditObservation{HTTPStatus: status}, nil
 }
@@ -366,8 +375,11 @@ func doLinkAuditRequest(ctx context.Context, client LinkAuditHTTPClient, method,
 	if err != nil {
 		return nil, err
 	}
-	if method == http.MethodGet && maxBodyBytes > 0 {
-		req.Header.Set("Range", "bytes=0-"+strconv.FormatInt(maxBodyBytes-1, 10))
+	if method == http.MethodGet {
+		req.Header.Set("Accept-Encoding", "identity")
+		if maxBodyBytes > 0 {
+			req.Header.Set("Range", "bytes=0-"+strconv.FormatInt(maxBodyBytes-1, 10))
+		}
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/courses/link_audit_client_test.go
+++ b/internal/courses/link_audit_client_test.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -220,6 +222,9 @@ func TestAuditCatalogLinksHTTPExecution(t *testing.T) {
 	if got := bodyReq.Header.Get("Range"); got != "bytes=0-3" {
 		t.Fatalf("Range = %q, want bytes=0-3", got)
 	}
+	if got := bodyReq.Header.Get("Accept-Encoding"); got != "identity" {
+		t.Fatalf("Accept-Encoding = %q, want identity", got)
+	}
 	if got := client.closedBodies.Load(); got < 5 {
 		t.Fatalf("closed bodies = %d, want all responses closed", got)
 	}
@@ -251,6 +256,69 @@ func TestAuditCatalogLinksValidatesInputsAndCancellation(t *testing.T) {
 	_, err := AuditCatalogLinks(ctx, catalog, testLinkAuditPolicy(), nil, &fakeAuditHTTPClient{}, time.Now())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("canceled error = %v, want context.Canceled", err)
+	}
+}
+
+func TestLinkAuditStatusOnlyFallbackUsesOneByteGET(t *testing.T) {
+	for _, headStatus := range []int{http.StatusMethodNotAllowed, http.StatusNotImplemented} {
+		t.Run(http.StatusText(headStatus), func(t *testing.T) {
+			policy := &LinkAuditPolicy{
+				MaxBodyBytes: 64,
+				Rules: []LinkAuditRule{{
+					HostSuffixes: []string{"127.0.0.1"},
+					DeadStatuses: []int{http.StatusNotFound},
+				}},
+			}
+			getHeaders := make(chan http.Header, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodHead {
+					w.WriteHeader(headStatus)
+					return
+				}
+				getHeaders <- r.Header.Clone()
+				_, _ = io.WriteString(w, strings.Repeat("x", int(policy.MaxBodyBytes)))
+			}))
+			t.Cleanup(server.Close)
+
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("url.Parse(%q): %v", server.URL, err)
+			}
+			var readBytes atomic.Int64
+			client := &bodyReadCountingClient{client: server.Client(), readBytes: &readBytes}
+
+			observation, err := requestLinkAuditObservation(
+				context.Background(),
+				linkAuditCandidate{rawURL: server.URL, host: serverURL.Hostname()},
+				policy,
+				client,
+			)
+			if err != nil {
+				t.Fatalf("requestLinkAuditObservation() error = %v", err)
+			}
+			if observation.HTTPStatus != http.StatusOK {
+				t.Fatalf("HTTPStatus = %d, want 200", observation.HTTPStatus)
+			}
+			if len(observation.Body) != 0 {
+				t.Fatalf("Body length = %d, want 0 for status-only audit", len(observation.Body))
+			}
+
+			var headers http.Header
+			select {
+			case headers = <-getHeaders:
+			case <-time.After(time.Second):
+				t.Fatal("GET request missing")
+			}
+			if got := headers.Get("Range"); got != "bytes=0-0" {
+				t.Fatalf("Range = %q, want bytes=0-0", got)
+			}
+			if got := headers.Get("Accept-Encoding"); got != "identity" {
+				t.Fatalf("Accept-Encoding = %q, want identity", got)
+			}
+			if got := readBytes.Load(); got > 1 {
+				t.Fatalf("response body bytes read = %d, want <= 1", got)
+			}
+		})
 	}
 }
 
@@ -361,6 +429,30 @@ type fakeAuditHTTPClient struct {
 type fakeHTTPResponse struct {
 	status int
 	body   string
+}
+
+type bodyReadCountingClient struct {
+	client    *http.Client
+	readBytes *atomic.Int64
+}
+
+func (c *bodyReadCountingClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if resp != nil && resp.Body != nil {
+		resp.Body = &readCountingBody{ReadCloser: resp.Body, readBytes: c.readBytes}
+	}
+	return resp, err
+}
+
+type readCountingBody struct {
+	io.ReadCloser
+	readBytes *atomic.Int64
+}
+
+func (b *readCountingBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	b.readBytes.Add(int64(n))
+	return n, err
 }
 
 func (f *fakeAuditHTTPClient) Do(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- use a one-byte range for status-only GET fallbacks after HEAD returns 405 or 501
- request identity encoding for all audit GETs
- keep body-rule reads capped, reading one extra byte before truncating to preserve classification input
- cover both fallback statuses, headers, and bounded response reads with a synthetic HTTP server

## Root cause

The shared HEAD fallback always used the policy body limit and read response content, even when the matching policy had no body-based rules.

## Validation

- `go test ./internal/courses -run 'Test(AuditCatalogLinksHTTPExecution|LinkAuditStatusOnlyFallbackUsesOneByteGET)$' -count=1`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `gopls check internal/courses/link_audit_client.go internal/courses/link_audit_client_test.go`
- `git diff --check origin/master...HEAD`