### PR TITLE
Fix post-normalization course deduplication

### DIFF
--- a/internal/courses/catalog.go
+++ b/internal/courses/catalog.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -469,6 +471,12 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 		}
 	}
 	unionSharedURLTitleVariants(source.CatalogEntries, clusters, options.LinkTombstones)
+	unionPostNormalizationTitleVariants(
+		source.Source.ChannelID,
+		source.CatalogEntries,
+		clusters,
+		options.TitleRules,
+	)
 
 	canonicalIndexes := make(map[int]int, len(source.CatalogEntries))
 	for index, entry := range source.CatalogEntries {
@@ -558,13 +566,14 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 
 		displayEntry, structurallyNormalized := repairLegacyDateRangeHeading(entry)
 		sourceTitle := cleanCourseTitle(displayEntry.Title)
+		sourceTitle, strippedTitleURL := stripExactExtractedTitleURL(sourceTitle, displayEntry.Links)
 		displayTitle := sourceTitle
 		normalized := false
 		if options.TitleRules != nil {
 			displayTitle, normalized = newTitleNormalizer(options.TitleRules).Normalize(sourceTitle)
 		}
 		var titleOriginal *string
-		if structurallyNormalized {
+		if structurallyNormalized || strippedTitleURL {
 			original := cleanCourseTitle(entry.Title)
 			titleOriginal = &original
 		} else if normalized {
@@ -607,7 +616,13 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 		}
 
 		if existingIndex, exists := entryIndexes[clusterRoot]; exists {
-			mergeCatalogEntry(&catalog.Entries[existingIndex], candidate)
+			if index == canonicalIndexes[clusterRoot] {
+				existing := catalog.Entries[existingIndex]
+				mergeCatalogEntry(&candidate, existing)
+				catalog.Entries[existingIndex] = candidate
+			} else {
+				mergeCatalogEntry(&catalog.Entries[existingIndex], candidate)
+			}
 			continue
 		}
 		entryIndexes[clusterRoot] = len(catalog.Entries)
@@ -1037,6 +1052,70 @@ func cleanCourseTitle(value string) string {
 	}
 }
 
+func stripExactExtractedTitleURL(title string, links []sourceLink) (string, bool) {
+	extractedURLs := make(map[string]struct{}, len(links))
+	for _, link := range links {
+		key, err := linkKey(link.URL)
+		if err != nil || !strings.HasPrefix(strings.ToLower(key), "http") {
+			continue
+		}
+		extractedURLs[key] = struct{}{}
+	}
+	if len(extractedURLs) == 0 {
+		return title, false
+	}
+
+	changed := false
+	for {
+		removed := false
+		for _, match := range httpURLPattern.FindAllStringIndex(title, -1) {
+			if !hasWhitespaceBoundaries(title, match[0], match[1]) {
+				continue
+			}
+			key, err := linkKey(title[match[0]:match[1]])
+			if err != nil {
+				continue
+			}
+			if _, exists := extractedURLs[key]; !exists {
+				continue
+			}
+
+			left := strings.TrimRightFunc(title[:match[0]], unicode.IsSpace)
+			right := strings.TrimLeftFunc(title[match[1]:], unicode.IsSpace)
+			if left == "" && right == "" {
+				continue
+			}
+			separator := ""
+			if left != "" && right != "" {
+				separator = " "
+			}
+			title = left + separator + right
+			changed = true
+			removed = true
+			break
+		}
+		if !removed {
+			return title, changed
+		}
+	}
+}
+
+func hasWhitespaceBoundaries(value string, start, end int) bool {
+	if start > 0 {
+		previous, _ := utf8.DecodeLastRuneInString(value[:start])
+		if !unicode.IsSpace(previous) {
+			return false
+		}
+	}
+	if end < len(value) {
+		next, _ := utf8.DecodeRuneInString(value[end:])
+		if !unicode.IsSpace(next) {
+			return false
+		}
+	}
+	return true
+}
+
 func repairLegacyDateRangeHeading(entry sourceEntry) (sourceEntry, bool) {
 	parsedTitle := collapseCourseHeadingWhitespace(entry.Title)
 	if !shortDatePattern.MatchString(parsedTitle) || entry.Credit.Author == nil {
@@ -1235,6 +1314,49 @@ func unionSharedURLTitleVariants(entries []sourceEntry, clusters *disjointSet, t
 					clusters.union(owners[leftIndex], owners[rightIndex])
 				}
 			}
+		}
+	}
+}
+
+func unionPostNormalizationTitleVariants(
+	channelID int64,
+	entries []sourceEntry,
+	clusters *disjointSet,
+	rules *TitleRules,
+) {
+	if rules == nil {
+		return
+	}
+
+	normalizer := newTitleNormalizer(rules)
+	ownersByIdentity := make(map[string][]int, len(entries))
+	changedIdentities := make(map[string]bool)
+	for index, entry := range entries {
+		displayEntry, _ := repairLegacyDateRangeHeading(entry)
+		sourceTitle := cleanCourseTitle(displayEntry.Title)
+		sourceTitle, _ = stripExactExtractedTitleURL(sourceTitle, displayEntry.Links)
+		displayTitle, changed := normalizer.Normalize(sourceTitle)
+		author := ""
+		if displayEntry.Credit.Author != nil {
+			author = normalizeSearchText(*displayEntry.Credit.Author)
+		}
+		identityKey := courseIdentityKeyFromParts(
+			channelID,
+			displayTitle,
+			author,
+			entry.Year,
+			entry.YearRange,
+		)
+		ownersByIdentity[identityKey] = append(ownersByIdentity[identityKey], index)
+		changedIdentities[identityKey] = changedIdentities[identityKey] || changed
+	}
+
+	for identityKey, owners := range ownersByIdentity {
+		if !changedIdentities[identityKey] {
+			continue
+		}
+		for _, owner := range owners[1:] {
+			clusters.union(owners[0], owner)
 		}
 	}
 }

--- a/internal/courses/catalog_test.go
+++ b/internal/courses/catalog_test.go
@@ -337,6 +337,244 @@ func TestBuildGzipWithTitleRulesNormalizesTransliteratedTitleWithoutChangingIden
 	}
 }
 
+func TestBuildGzipMergesTitlesThatConvergeOnlyAfterNormalization(t *testing.T) {
+	year := 2024
+	first := validSourceEntry()
+	first.Title = "Analiz dannyih na Python"
+	first.Credit.Author = stringPointer("Example Academy")
+	first.Year = &year
+	first.RawBlock = "[Example Academy] Analiz dannyih na Python"
+	first.Links[0].URL = "https://files.example.test/course-first"
+
+	second := first
+	second.EntryID = "1:2:0"
+	second.MessageID = "1:2"
+	second.SourceMessageIDs = []string{"1:2"}
+	second.AddedAt = "2024-02-01T00:00:00Z"
+	second.Title = "Анализ данных на Python"
+	second.RawBlock = "[Example Academy] Анализ данных на Python"
+	second.Links = append([]sourceLink(nil), first.Links...)
+	second.Links[0].URL = "https://files.example.test/course-second"
+
+	source := validSource(t, first)
+	source.Messages = append(source.Messages, sourceMessage{
+		MessageID:         "1:2",
+		TelegramMessageID: 2,
+		URL:               "https://messages.example.test/source/2",
+	})
+	source.CatalogEntries = []sourceEntry{second, first}
+	setSourceCounts(&source)
+	expectedID := courseID(courseIdentityKey(source.Source.ChannelID, first))
+	rules := titleRulesForTest(t, `{
+		"schema_version":"title-normalization-rules/v2",
+		"protected_tokens_ci":[],
+		"protected_tokens_exact":[],
+		"protected_substrings_ci":[],
+		"force_normalize_tokens_ci":[],
+		"force_normalize_phrases_ci":[],
+		"structural_cleanup":{
+			"decode_html_entities":false,
+			"drop_zero_width_format_chars":false,
+			"underscores_as_spaces":false,
+			"strip_leading_provider_noise":false
+		}
+	}`)
+
+	var output bytes.Buffer
+	stats, err := BuildGzipFromSourcesWithOptions(
+		[]SourceInput{{Reader: sourceReader(t, source), Name: "synthetic.json"}},
+		&output,
+		BuildOptions{TitleRules: rules},
+	)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	if stats.SourceEntries != 2 || stats.Entries != 1 || stats.SourceLinks != 2 ||
+		stats.Links != 2 || stats.NormalizedTitles != 1 {
+		t.Fatalf("stats = %+v, want one normalized course with two source links", stats)
+	}
+
+	catalog := decodeBuiltCatalog(t, &output)
+	if len(catalog.Entries) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(catalog.Entries))
+	}
+	got := catalog.Entries[0]
+	if got.ID != expectedID {
+		t.Fatalf("course ID = %q, want canonical raw-title identity %q", got.ID, expectedID)
+	}
+	if got.Title != "Анализ данных на Python" {
+		t.Fatalf("title = %q, want normalized display title", got.Title)
+	}
+	if got.TitleOriginal == nil || *got.TitleOriginal != first.Title {
+		t.Fatalf("title_original = %v, want canonical raw title %q", got.TitleOriginal, first.Title)
+	}
+	if len(got.Links) != 2 {
+		t.Fatalf("links = %+v, want both source links", got.Links)
+	}
+	if len(got.Sources) != 2 ||
+		got.Sources[0].EntryID != first.EntryID ||
+		got.Sources[1].EntryID != second.EntryID {
+		t.Fatalf("sources = %+v, want both source messages", got.Sources)
+	}
+}
+
+func TestBuildGzipDoesNotMergeNormalizedTitlesAcrossDifferentYears(t *testing.T) {
+	firstYear := 2023
+	secondYear := 2024
+	first := validSourceEntry()
+	first.Title = "Analiz dannyih na Python"
+	first.Credit.Author = stringPointer("Example Academy")
+	first.Year = &firstYear
+	first.RawBlock = "[Example Academy] Analiz dannyih na Python"
+	first.Links[0].URL = "https://files.example.test/course-first"
+
+	second := first
+	second.EntryID = "1:2:0"
+	second.MessageID = "1:2"
+	second.SourceMessageIDs = []string{"1:2"}
+	second.AddedAt = "2024-02-01T00:00:00Z"
+	second.Title = "Анализ данных на Python"
+	second.Year = &secondYear
+	second.RawBlock = "[Example Academy] Анализ данных на Python"
+	second.Links = append([]sourceLink(nil), first.Links...)
+	second.Links[0].URL = "https://files.example.test/course-second"
+
+	source := validSource(t, first)
+	source.Messages = append(source.Messages, sourceMessage{
+		MessageID:         "1:2",
+		TelegramMessageID: 2,
+		URL:               "https://messages.example.test/source/2",
+	})
+	source.CatalogEntries = []sourceEntry{first, second}
+	setSourceCounts(&source)
+	rules := titleRulesForTest(t, `{
+		"schema_version":"title-normalization-rules/v2",
+		"protected_tokens_ci":[],
+		"protected_tokens_exact":[],
+		"protected_substrings_ci":[],
+		"force_normalize_tokens_ci":[],
+		"force_normalize_phrases_ci":[],
+		"structural_cleanup":{
+			"decode_html_entities":false,
+			"drop_zero_width_format_chars":false,
+			"underscores_as_spaces":false,
+			"strip_leading_provider_noise":false
+		}
+	}`)
+
+	var output bytes.Buffer
+	stats, err := BuildGzipFromSourcesWithOptions(
+		[]SourceInput{{Reader: sourceReader(t, source), Name: "synthetic.json"}},
+		&output,
+		BuildOptions{TitleRules: rules},
+	)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	if stats.Entries != 2 || stats.Links != 2 {
+		t.Fatalf("stats = %+v, want distinct courses for different years", stats)
+	}
+
+	catalog := decodeBuiltCatalog(t, &output)
+	gotIDs := make(map[string]struct{}, len(catalog.Entries))
+	for _, entry := range catalog.Entries {
+		gotIDs[entry.ID] = struct{}{}
+	}
+	for _, entry := range []sourceEntry{first, second} {
+		expectedID := courseID(courseIdentityKey(source.Source.ChannelID, entry))
+		if _, exists := gotIDs[expectedID]; !exists {
+			t.Fatalf("course IDs = %v, want raw identity %q", gotIDs, expectedID)
+		}
+	}
+}
+
+func TestBuildGzipStripsExactExtractedURLFromDisplayTitle(t *testing.T) {
+	entry := validSourceEntry()
+	entry.Title = "Practical Go https://files.example.test/course More Exercises"
+	entry.RawBlock = entry.Title
+	entry.Links[0].URL = "https://files.example.test/course"
+	source := validSource(t, entry)
+	expectedID := courseID(courseIdentityKey(source.Source.ChannelID, entry))
+
+	var output bytes.Buffer
+	stats, err := BuildGzip(sourceReader(t, source), &output)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	if stats.Entries != 1 || stats.Links != 1 || stats.NormalizedTitles != 1 {
+		t.Fatalf("stats = %+v, want one cleaned course with its extracted link", stats)
+	}
+
+	got := decodeBuiltCatalog(t, &output).Entries[0]
+	if got.ID != expectedID {
+		t.Fatalf("course ID = %q, want existing URL-insensitive identity %q", got.ID, expectedID)
+	}
+	if got.Title != "Practical Go More Exercises" {
+		t.Fatalf("title = %q, want exact extracted URL removed", got.Title)
+	}
+	if got.TitleOriginal == nil || *got.TitleOriginal != entry.Title {
+		t.Fatalf("title_original = %v, want raw title %q", got.TitleOriginal, entry.Title)
+	}
+	if len(got.Links) != 1 || got.Links[0].URL != entry.Links[0].URL {
+		t.Fatalf("links = %+v, want extracted link preserved", got.Links)
+	}
+	if len(got.Sources) != 1 || got.Sources[0].EntryID != entry.EntryID {
+		t.Fatalf("sources = %+v, want provenance preserved", got.Sources)
+	}
+}
+
+func TestBuildGzipDoesNotStripUnmatchedOrBareDomainTitleText(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		linkURL string
+	}{
+		{
+			name:    "different extracted URL",
+			title:   "Practical Go https://files.example.test/course More Exercises",
+			linkURL: "https://files.example.test/different",
+		},
+		{
+			name:    "bare domain",
+			title:   "Practical Go files.example.test More Exercises",
+			linkURL: "https://files.example.test/different",
+		},
+		{
+			name:    "URL only",
+			title:   "https://files.example.test/course",
+			linkURL: "https://files.example.test/course",
+		},
+		{
+			name:    "URL with punctuation",
+			title:   "Practical Go https://files.example.test/course.",
+			linkURL: "https://files.example.test/course",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry := validSourceEntry()
+			entry.Title = test.title
+			entry.RawBlock = entry.Title
+			entry.Links[0].URL = test.linkURL
+			source := validSource(t, entry)
+
+			var output bytes.Buffer
+			if _, err := BuildGzip(sourceReader(t, source), &output); err != nil {
+				t.Fatalf("build catalog: %v", err)
+			}
+
+			got := decodeBuiltCatalog(t, &output).Entries[0]
+			if got.Title != test.title {
+				t.Fatalf("title = %q, want unchanged %q", got.Title, test.title)
+			}
+			if got.TitleOriginal != nil {
+				t.Fatalf("title_original = %v, want nil", got.TitleOriginal)
+			}
+		})
+	}
+}
+
 func TestBuildGzipCountsCleanupOnlyTitleWithoutChangingIdentity(t *testing.T) {
 	entry := validSourceEntry()
 	entry.Title = `"'9.[Provider]_Alpha__Beta`


### PR DESCRIPTION
## Summary

- merge course variants that converge only after title-rule normalization, guarded by channel, normalized author, and exact year or year range
- preserve the canonical raw identity and canonical title fields while unioning links, sources, and other metadata independent of input order
- remove only exact whitespace-delimited extracted HTTP URLs from display titles, preserving the link, provenance, original title, and URL-insensitive ID

## Root cause

Course clustering completed before display title normalization, so raw-title variants could render identically but remain separate entries. Extracted HTTP links could also remain embedded in display titles because display cleanup did not consult the entry link set.

## Validation

- `go test ./internal/courses -run '^(TestBuildGzipMergesTitlesThatConvergeOnlyAfterNormalization|TestBuildGzipDoesNotMergeNormalizedTitlesAcrossDifferentYears|TestBuildGzipStripsExactExtractedURLFromDisplayTitle|TestBuildGzipDoesNotStripUnmatchedOrBareDomainTitleText)$' -count=1`\n- `go test ./... -count=1`\n- `go test -race ./... -count=1`\n- `go vet ./...`\n- `gopls check internal/courses/catalog.go internal/courses/catalog_test.go`\n- Node syntax checks and `node --test tests/*.test.js`\n- `gofmt`, `git diff --check`, and public-diff privacy scan\n\nIndependent review: approved with no remaining findings.