### PR TITLE
Add occurrence-specific link suppressions

### DIFF
--- a/cmd/courses-data/main.go
+++ b/cmd/courses-data/main.go
@@ -16,7 +16,7 @@ func main() {
 	config, err := parseArgs(os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, "usage: courses-data --input <export.json> [--input <export.json>...] [--input-dir <exports-dir>] --output <catalog.json.gz> [--torrent-dir <dir>] [--title-rules <rules.json>] [--link-tombstones <tombstones.json>] [--link-enrichment <cache.json>]")
+		fmt.Fprintln(os.Stderr, "usage: courses-data --input <export.json> [--input <export.json>...] [--input-dir <exports-dir>] --output <catalog.json.gz> [--torrent-dir <dir>] [--title-rules <rules.json>] [--link-tombstones <tombstones.json>] [--link-suppressions <suppressions.json>] [--link-enrichment <cache.json>]")
 		fmt.Fprintln(os.Stderr, "   or: courses-data <telegram-export.json> <catalog.json.gz> [torrent-dir]")
 		os.Exit(2)
 	}
@@ -26,6 +26,7 @@ func main() {
 		config.TorrentDir,
 		config.TitleRulesPath,
 		config.LinkTombstonesPath,
+		config.LinkSuppressionsPath,
 		config.LinkEnrichmentPath,
 	); err != nil {
 		fmt.Fprintln(os.Stderr, "build courses catalog:", err)
@@ -34,12 +35,13 @@ func main() {
 }
 
 type config struct {
-	InputPaths         []string
-	OutputPath         string
-	TorrentDir         string
-	TitleRulesPath     string
-	LinkTombstonesPath string
-	LinkEnrichmentPath string
+	InputPaths           []string
+	OutputPath           string
+	TorrentDir           string
+	TitleRulesPath       string
+	LinkTombstonesPath   string
+	LinkSuppressionsPath string
+	LinkEnrichmentPath   string
 }
 
 type repeatedStrings []string
@@ -79,6 +81,7 @@ func parseArgs(args []string) (config, error) {
 	flags.StringVar(&result.TorrentDir, "torrent-dir", "", "directory containing downloaded .torrent files")
 	flags.StringVar(&result.TitleRulesPath, "title-rules", "", "title normalization rules JSON path")
 	flags.StringVar(&result.LinkTombstonesPath, "link-tombstones", "", "link tombstones JSON path")
+	flags.StringVar(&result.LinkSuppressionsPath, "link-suppressions", "", "occurrence-specific link suppressions JSON path")
 	flags.StringVar(&result.LinkEnrichmentPath, "link-enrichment", "", "link enrichment cache JSON path")
 	if err := flags.Parse(args); err != nil {
 		return config{}, err
@@ -124,15 +127,22 @@ func buildFile(inputPath, outputPath, torrentDir string) error {
 }
 
 func buildFiles(inputPaths []string, outputPath, torrentDir, titleRulesPath, linkTombstonesPath string) error {
-	return buildFilesWithLinkEnrichment(inputPaths, outputPath, torrentDir, titleRulesPath, linkTombstonesPath, "")
+	return buildFilesWithLinkEnrichment(inputPaths, outputPath, torrentDir, titleRulesPath, linkTombstonesPath, "", "")
 }
 
-func buildFilesWithLinkEnrichment(inputPaths []string, outputPath, torrentDir, titleRulesPath, linkTombstonesPath, linkEnrichmentPath string) error {
+func buildFilesWithLinkEnrichment(
+	inputPaths []string,
+	outputPath, torrentDir, titleRulesPath, linkTombstonesPath, linkSuppressionsPath, linkEnrichmentPath string,
+) error {
 	titleRules, err := loadTitleRulesFile(titleRulesPath)
 	if err != nil {
 		return err
 	}
 	linkTombstones, err := loadLinkTombstonesFile(linkTombstonesPath)
+	if err != nil {
+		return err
+	}
+	linkSuppressions, err := loadLinkSuppressionsFile(linkSuppressionsPath)
 	if err != nil {
 		return err
 	}
@@ -169,10 +179,11 @@ func buildFilesWithLinkEnrichment(inputPaths []string, outputPath, torrentDir, t
 	defer os.Remove(tempPath)
 
 	stats, buildErr := courses.BuildGzipFromSourcesWithOptions(inputs, temp, courses.BuildOptions{
-		TorrentDir:     torrentDir,
-		TitleRules:     titleRules,
-		LinkTombstones: linkTombstones,
-		LinkEnrichment: linkEnrichment,
+		TorrentDir:       torrentDir,
+		TitleRules:       titleRules,
+		LinkTombstones:   linkTombstones,
+		LinkSuppressions: linkSuppressions,
+		LinkEnrichment:   linkEnrichment,
 	})
 	closeErr := temp.Close()
 	if buildErr != nil {
@@ -233,6 +244,23 @@ func loadLinkTombstonesFile(path string) (*courses.LinkTombstones, error) {
 		return nil, fmt.Errorf("load link tombstones %q: %w", path, err)
 	}
 	return tombstones, nil
+}
+
+func loadLinkSuppressionsFile(path string) (*courses.LinkSuppressions, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("load link suppressions %q: %w", path, err)
+	}
+	defer file.Close()
+	suppressions, err := courses.LoadLinkSuppressions(file)
+	if err != nil {
+		return nil, fmt.Errorf("load link suppressions %q: %w", path, err)
+	}
+	return suppressions, nil
 }
 
 func loadTitleRulesFile(path string) (*courses.TitleRules, error) {

--- a/cmd/courses-data/main_test.go
+++ b/cmd/courses-data/main_test.go
@@ -170,6 +170,28 @@ func TestParseArgsAcceptsLinkTombstones(t *testing.T) {
 	}
 }
 
+func TestParseArgsAcceptsLinkSuppressions(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "source.json")
+	outputPath := filepath.Join(dir, "catalog.json.gz")
+	suppressionsPath := filepath.Join(dir, "link-suppressions.json")
+
+	config, err := parseArgs([]string{
+		"--input", inputPath,
+		"--output", outputPath,
+		"--link-suppressions", suppressionsPath,
+	})
+	if err != nil {
+		t.Fatalf("parse args: %v", err)
+	}
+	if config.LinkSuppressionsPath != suppressionsPath {
+		t.Fatalf("link suppressions path = %q, want %q", config.LinkSuppressionsPath, suppressionsPath)
+	}
+	if config.InputPaths[0] != inputPath || config.OutputPath != outputPath {
+		t.Fatalf("config lost existing args: %+v", config)
+	}
+}
+
 func TestParseArgsAcceptsLinkEnrichment(t *testing.T) {
 	dir := t.TempDir()
 	inputPath := filepath.Join(dir, "source.json")
@@ -219,6 +241,7 @@ func TestBuildFilesWithLinkEnrichmentEmitsCachedContent(t *testing.T) {
 		"",
 		"",
 		"",
+		"",
 		enrichmentPath,
 	); err != nil {
 		t.Fatalf("build files: %v", err)
@@ -249,6 +272,7 @@ func TestBuildFilesMalformedLinkEnrichmentDoesNotOpenSourcesOrReplaceOutput(t *t
 		"",
 		"",
 		"",
+		"",
 		enrichmentPath,
 	)
 	if err == nil {
@@ -257,6 +281,87 @@ func TestBuildFilesMalformedLinkEnrichmentDoesNotOpenSourcesOrReplaceOutput(t *t
 	if !strings.Contains(err.Error(), "load link enrichment") ||
 		!strings.Contains(err.Error(), enrichmentPath) {
 		t.Fatalf("error = %v, want contextual enrichment path", err)
+	}
+	if got, readErr := os.ReadFile(outputPath); readErr != nil || string(got) != sentinel {
+		t.Fatalf("output changed: %q, error=%v", string(got), readErr)
+	}
+}
+
+func TestBuildFilesWithLinkSuppressionsConsumesPrivateSidecar(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "source.json")
+	outputPath := filepath.Join(dir, "catalog.json.gz")
+	suppressionsPath := filepath.Join(dir, "link-suppressions.json")
+	const entryID = "1:1:0"
+	const rawURL = "https://example.test/course/1:1"
+	if err := os.WriteFile(
+		inputPath,
+		[]byte(sourceWithTitleJSON(entryID, "1:1", 1, "Suppressed Course")),
+		0o600,
+	); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	hash := sha256.Sum256([]byte(rawURL))
+	if err := os.WriteFile(suppressionsPath, []byte(fmt.Sprintf(`{
+		"schema_version":"link-suppressions/v1",
+		"canonicalization_version":1,
+		"suppressions":[{
+			"source_entry_id":%q,
+			"sha256":"%x",
+			"reason":"manual",
+			"confirmed_at":"2026-07-27T00:00:00Z"
+		}]
+	}`, entryID, hash)), 0o600); err != nil {
+		t.Fatalf("write suppressions: %v", err)
+	}
+
+	if err := buildFilesWithLinkEnrichment(
+		[]string{inputPath},
+		outputPath,
+		"",
+		"",
+		"",
+		suppressionsPath,
+		"",
+	); err != nil {
+		t.Fatalf("build files: %v", err)
+	}
+	payload := readGzipFile(t, outputPath)
+	if !strings.Contains(payload, `"suppressed_links_removed":1`) ||
+		!strings.Contains(payload, `"entries_without_links_removed":1`) ||
+		!strings.Contains(payload, `"entries":[]`) {
+		t.Fatalf("catalog did not apply link suppression: %s", payload)
+	}
+}
+
+func TestBuildFilesMalformedLinkSuppressionsDoesNotOpenSourcesOrReplaceOutput(t *testing.T) {
+	dir := t.TempDir()
+	missingInputPath := filepath.Join(dir, "missing-source.json")
+	outputPath := filepath.Join(dir, "catalog.json.gz")
+	suppressionsPath := filepath.Join(dir, "link-suppressions.json")
+	const sentinel = "sentinel output"
+	if err := os.WriteFile(outputPath, []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("write sentinel output: %v", err)
+	}
+	if err := os.WriteFile(suppressionsPath, []byte(`{"schema_version":"bad"}`), 0o600); err != nil {
+		t.Fatalf("write malformed suppressions: %v", err)
+	}
+
+	err := buildFilesWithLinkEnrichment(
+		[]string{missingInputPath},
+		outputPath,
+		"",
+		"",
+		"",
+		suppressionsPath,
+		"",
+	)
+	if err == nil {
+		t.Fatal("build files succeeded with malformed link suppressions")
+	}
+	if !strings.Contains(err.Error(), "load link suppressions") ||
+		!strings.Contains(err.Error(), suppressionsPath) {
+		t.Fatalf("error = %v, want contextual suppressions path", err)
 	}
 	if got, readErr := os.ReadFile(outputPath); readErr != nil || string(got) != sentinel {
 		t.Fatalf("output changed: %q, error=%v", string(got), readErr)

--- a/internal/courses/catalog.go
+++ b/internal/courses/catalog.go
@@ -46,10 +46,11 @@ type SourceInput struct {
 }
 
 type BuildOptions struct {
-	TorrentDir     string
-	TitleRules     *TitleRules
-	LinkTombstones *LinkTombstones
-	LinkEnrichment *LinkEnrichmentCache
+	TorrentDir       string
+	TitleRules       *TitleRules
+	LinkTombstones   *LinkTombstones
+	LinkSuppressions *LinkSuppressions
+	LinkEnrichment   *LinkEnrichmentCache
 }
 
 type catalogSource struct {
@@ -126,6 +127,7 @@ type CatalogStats struct {
 	SourcePasswords            int `json:"source_passwords"`
 	StructuralLinksRemoved     int `json:"structural_links_removed"`
 	TombstonedLinksRemoved     int `json:"tombstoned_links_removed"`
+	SuppressedLinksRemoved     int `json:"suppressed_links_removed"`
 	EntriesWithoutLinksRemoved int `json:"entries_without_links_removed"`
 	Entries                    int `json:"entries"`
 	Links                      int `json:"links"`
@@ -451,6 +453,9 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 			if options.LinkTombstones.ContainsURL(link.URL) {
 				continue
 			}
+			if options.LinkSuppressions.ContainsURL(entry.EntryID, link.URL) {
+				continue
+			}
 			canonicalLinkKey, err := linkKey(link.URL)
 			if err != nil {
 				continue
@@ -470,7 +475,7 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 			}
 		}
 	}
-	unionSharedURLTitleVariants(source.CatalogEntries, clusters, options.LinkTombstones)
+	unionSharedURLTitleVariants(source.CatalogEntries, clusters, options.LinkTombstones, options.LinkSuppressions)
 	unionPostNormalizationTitleVariants(
 		source.Source.ChannelID,
 		source.CatalogEntries,
@@ -541,6 +546,10 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 				catalog.Stats.TombstonedLinksRemoved++
 				continue
 			}
+			if options.LinkSuppressions.ContainsURL(entry.EntryID, link.URL) {
+				catalog.Stats.SuppressedLinksRemoved++
+				continue
+			}
 			if actionableSourceLink(entry, link) {
 				catalogLink := catalogLinkFromSource(link)
 				catalogLink.Content = cachedLinkContent(options.LinkEnrichment, link.URL)
@@ -550,6 +559,8 @@ func buildGzipFromSource(source sourceExport, output io.Writer, options BuildOpt
 		if torrentLink, ok := torrentLinks[entry.MessageID]; ok {
 			if options.LinkTombstones.ContainsURL(torrentLink.URL) {
 				catalog.Stats.TombstonedLinksRemoved++
+			} else if options.LinkSuppressions.ContainsURL(entry.EntryID, torrentLink.URL) {
+				catalog.Stats.SuppressedLinksRemoved++
 			} else {
 				torrentLink.Content = cachedLinkContent(options.LinkEnrichment, torrentLink.URL)
 				links = mergeLinks(links, []CatalogLink{torrentLink})
@@ -1291,11 +1302,19 @@ func malformedAuthorTitle(title string) (string, string, bool) {
 	return "", "", false
 }
 
-func unionSharedURLTitleVariants(entries []sourceEntry, clusters *disjointSet, tombstones *LinkTombstones) {
+func unionSharedURLTitleVariants(
+	entries []sourceEntry,
+	clusters *disjointSet,
+	tombstones *LinkTombstones,
+	suppressions *LinkSuppressions,
+) {
 	ownersByURL := make(map[string][]int)
 	for index, entry := range entries {
 		for _, link := range entry.Links {
 			if tombstones.ContainsURL(link.URL) {
+				continue
+			}
+			if suppressions.ContainsURL(entry.EntryID, link.URL) {
 				continue
 			}
 			key, err := linkKey(link.URL)

--- a/internal/courses/catalog_test.go
+++ b/internal/courses/catalog_test.go
@@ -1616,6 +1616,118 @@ func TestBuildGzipWithLinkTombstonesDoesNotClusterByTombstonedSharedURL(t *testi
 	}
 }
 
+func TestBuildGzipWithLinkSuppressionsRemovesOnlyTheConfiguredSourceOccurrence(t *testing.T) {
+	first := validSourceEntry()
+	first.Title = "Shared Course"
+	first.Credit.Author = stringPointer("First Author")
+	first.Links[0].URL = "HTTPS://Example.Test:443/course#suppressed"
+	second := first
+	second.EntryID = "1:2:0"
+	second.MessageID = "1:2"
+	second.SourceMessageIDs = []string{"1:2"}
+	second.Credit.Author = stringPointer("Second Author")
+	second.Links = append([]sourceLink(nil), first.Links...)
+	second.Links[0].URL = "https://example.test/course#kept"
+
+	source := validSource(t, first)
+	source.Messages = append(source.Messages, sourceMessage{
+		MessageID:         second.MessageID,
+		TelegramMessageID: 2,
+		URL:               "https://example.test/messages/2",
+	})
+	source.CatalogEntries = []sourceEntry{first, second}
+	setSourceCounts(&source)
+	suppressions := linkSuppressionsForTest(t, first.EntryID, first.Links[0].URL)
+
+	var output bytes.Buffer
+	stats, err := BuildGzipFromSourcesWithOptions(
+		[]SourceInput{{Reader: sourceReader(t, source), Name: "source.json"}},
+		&output,
+		BuildOptions{LinkSuppressions: suppressions},
+	)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	if stats.SourceLinks != 2 ||
+		stats.SuppressedLinksRemoved != 1 ||
+		stats.EntriesWithoutLinksRemoved != 1 ||
+		stats.Entries != 1 ||
+		stats.Links != 1 {
+		t.Fatalf("stats = %+v, want one suppressed occurrence, one removed entry, and one kept link", stats)
+	}
+	catalog := decodeBuiltCatalog(t, &output)
+	if len(catalog.Entries) != 1 ||
+		len(catalog.Entries[0].Links) != 1 ||
+		catalog.Entries[0].Links[0].URL != second.Links[0].URL ||
+		len(catalog.Entries[0].Sources) != 1 ||
+		catalog.Entries[0].Sources[0].EntryID != second.EntryID {
+		t.Fatalf("entries = %+v, want only the unaffected second occurrence", catalog.Entries)
+	}
+}
+
+func TestBuildGzipWithLinkSuppressionsKeysTorrentOccurrencesBySourceEntry(t *testing.T) {
+	first := validSourceEntry()
+	first.Title = "First Torrent Course"
+	first.Links = nil
+	first.Origin = "document"
+	first.Availability = "document_attachment"
+	second := first
+	second.EntryID = "1:2:0"
+	second.MessageID = "1:2"
+	second.SourceMessageIDs = []string{"1:2"}
+	second.Title = "Second Torrent Course"
+
+	source := validSource(t, first)
+	source.Messages[0].Media.Type = "messageMediaDocument"
+	source.Messages[0].Media.Document.FileName = "First.torrent"
+	source.Messages[0].Media.Document.MIMEType = "application/x-bittorrent"
+	secondMessage := sourceMessage{
+		MessageID:         second.MessageID,
+		TelegramMessageID: 2,
+		URL:               "https://example.test/messages/2",
+	}
+	secondMessage.Media.Type = "messageMediaDocument"
+	secondMessage.Media.Document.FileName = "Second.torrent"
+	secondMessage.Media.Document.MIMEType = "application/x-bittorrent"
+	source.Messages = append(source.Messages, secondMessage)
+	source.CatalogEntries = []sourceEntry{first, second}
+	setSourceCounts(&source)
+
+	torrentDir := t.TempDir()
+	torrentPayload, torrentInfo := validTorrentPayload()
+	for _, name := range []string{"First.torrent", "Second.torrent"} {
+		if err := os.WriteFile(filepath.Join(torrentDir, name), torrentPayload, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	magnet := "magnet:?xt=urn:btih:" + sha1Hex(torrentInfo)
+	suppressions := linkSuppressionsForTest(t, first.EntryID, magnet)
+
+	var output bytes.Buffer
+	stats, err := BuildGzipFromSourcesWithOptions(
+		[]SourceInput{{Reader: sourceReader(t, source), Name: "source.json"}},
+		&output,
+		BuildOptions{TorrentDir: torrentDir, LinkSuppressions: suppressions},
+	)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	if stats.SourceLinks != 0 ||
+		stats.SuppressedLinksRemoved != 1 ||
+		stats.EntriesWithoutLinksRemoved != 1 ||
+		stats.Entries != 1 ||
+		stats.Links != 1 {
+		t.Fatalf("stats = %+v, want one suppressed torrent occurrence and one kept occurrence", stats)
+	}
+	catalog := decodeBuiltCatalog(t, &output)
+	if len(catalog.Entries) != 1 ||
+		len(catalog.Entries[0].Links) != 1 ||
+		catalog.Entries[0].Links[0].URL != magnet ||
+		catalog.Entries[0].Sources[0].EntryID != second.EntryID {
+		t.Fatalf("entries = %+v, want unaffected second torrent occurrence", catalog.Entries)
+	}
+}
+
 func validSource(t *testing.T, entry sourceEntry) sourceExport {
 	t.Helper()
 

--- a/internal/courses/link_suppressions.go
+++ b/internal/courses/link_suppressions.go
@@ -1,0 +1,153 @@
+package courses
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const linkSuppressionsSchema = "link-suppressions/v1"
+
+var linkSuppressionHashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+type LinkSuppressions struct {
+	records map[linkSuppressionKey]linkSuppressionRecord
+}
+
+type linkSuppressionsFile struct {
+	SchemaVersion           string            `json:"schema_version"`
+	CanonicalizationVersion int               `json:"canonicalization_version"`
+	Suppressions            []json.RawMessage `json:"suppressions"`
+}
+
+type linkSuppressionKey struct {
+	SourceEntryID string
+	SHA256        string
+}
+
+type linkSuppressionRecord struct {
+	SourceEntryID string `json:"source_entry_id"`
+	SHA256        string `json:"sha256"`
+	Reason        string `json:"reason"`
+	ConfirmedAt   string `json:"confirmed_at"`
+}
+
+func LoadLinkSuppressions(r io.Reader) (*LinkSuppressions, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read link suppressions: %w", err)
+	}
+	if !utf8.Valid(data) {
+		return nil, fmt.Errorf("read link suppressions: invalid utf-8")
+	}
+	if err := rejectDuplicateTopLevelKeys(data); err != nil {
+		return nil, fmt.Errorf("decode link suppressions: %w", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var file linkSuppressionsFile
+	if err := decoder.Decode(&file); err != nil {
+		return nil, fmt.Errorf("decode link suppressions: %w", err)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("decode link suppressions: multiple json values")
+		}
+		return nil, fmt.Errorf("decode link suppressions: %w", err)
+	}
+	if file.SchemaVersion != linkSuppressionsSchema {
+		return nil, fmt.Errorf("decode link suppressions: unsupported schema_version %q", file.SchemaVersion)
+	}
+	if file.CanonicalizationVersion != 1 {
+		return nil, fmt.Errorf("decode link suppressions: unsupported canonicalization_version %d", file.CanonicalizationVersion)
+	}
+	if file.Suppressions == nil {
+		return nil, fmt.Errorf("decode link suppressions: suppressions is required")
+	}
+
+	suppressions := &LinkSuppressions{records: make(map[linkSuppressionKey]linkSuppressionRecord)}
+	for index, raw := range file.Suppressions {
+		if err := rejectDuplicateTopLevelKeys(raw); err != nil {
+			return nil, fmt.Errorf("decode link suppressions: suppressions[%d]: %w", index, err)
+		}
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.DisallowUnknownFields()
+		var record linkSuppressionRecord
+		if err := decoder.Decode(&record); err != nil {
+			return nil, fmt.Errorf("decode link suppressions: suppressions[%d]: %w", index, err)
+		}
+		if record.SourceEntryID == "" || strings.TrimSpace(record.SourceEntryID) != record.SourceEntryID {
+			return nil, fmt.Errorf("decode link suppressions: suppressions[%d] has invalid source_entry_id", index)
+		}
+		if !linkSuppressionHashPattern.MatchString(record.SHA256) {
+			return nil, fmt.Errorf("decode link suppressions: suppressions[%d] has invalid sha256", index)
+		}
+		if !validLinkSuppressionReason(record.Reason) {
+			return nil, fmt.Errorf("decode link suppressions: suppressions[%d] has invalid reason %q", index, record.Reason)
+		}
+		if _, err := time.Parse(time.RFC3339, record.ConfirmedAt); err != nil {
+			return nil, fmt.Errorf("decode link suppressions: suppressions[%d] has invalid confirmed_at %q: %w", index, record.ConfirmedAt, err)
+		}
+		key := linkSuppressionKey{SourceEntryID: record.SourceEntryID, SHA256: record.SHA256}
+		if _, exists := suppressions.records[key]; exists {
+			return nil, fmt.Errorf(
+				"decode link suppressions: duplicate source_entry_id %q and sha256 %q",
+				record.SourceEntryID,
+				record.SHA256,
+			)
+		}
+		suppressions.records[key] = record
+	}
+	return suppressions, nil
+}
+
+func (s *LinkSuppressions) ContainsURL(sourceEntryID, rawURL string) bool {
+	if s == nil || len(s.records) == 0 {
+		return false
+	}
+	hash, err := linkHash(rawURL)
+	if err != nil {
+		return false
+	}
+	_, exists := s.records[linkSuppressionKey{SourceEntryID: sourceEntryID, SHA256: hash}]
+	return exists
+}
+
+func (s LinkSuppressions) MarshalJSON() ([]byte, error) {
+	records := make([]linkSuppressionRecord, 0, len(s.records))
+	for _, record := range s.records {
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].SourceEntryID != records[j].SourceEntryID {
+			return records[i].SourceEntryID < records[j].SourceEntryID
+		}
+		return records[i].SHA256 < records[j].SHA256
+	})
+	return json.Marshal(struct {
+		SchemaVersion           string                  `json:"schema_version"`
+		CanonicalizationVersion int                     `json:"canonicalization_version"`
+		Suppressions            []linkSuppressionRecord `json:"suppressions"`
+	}{
+		SchemaVersion:           linkSuppressionsSchema,
+		CanonicalizationVersion: 1,
+		Suppressions:            records,
+	})
+}
+
+func validLinkSuppressionReason(reason string) bool {
+	switch reason {
+	case "content_mismatch", "manual":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/courses/link_suppressions_test.go
+++ b/internal/courses/link_suppressions_test.go
@@ -1,0 +1,157 @@
+package courses
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestLoadLinkSuppressionsMatchesOnlyTheConfiguredEntryOccurrence(t *testing.T) {
+	hash := hashForTest(t, "https://example.test/course")
+	suppressions, err := LoadLinkSuppressions(strings.NewReader(`{
+		"schema_version":"link-suppressions/v1",
+		"canonicalization_version":1,
+		"suppressions":[{
+			"source_entry_id":"1:1:0",
+			"sha256":"` + hash + `",
+			"reason":"content_mismatch",
+			"confirmed_at":"2026-07-27T00:00:00Z"
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("LoadLinkSuppressions() error = %v", err)
+	}
+	if !suppressions.ContainsURL("1:1:0", "HTTPS://Example.Test:443/course#fragment") {
+		t.Fatal("ContainsURL() = false, want canonical URL occurrence match")
+	}
+	if suppressions.ContainsURL("1:2:0", "https://example.test/course") {
+		t.Fatal("ContainsURL() = true for a different source_entry_id")
+	}
+	if suppressions.ContainsURL("1:1:0", "https://example.test/other") {
+		t.Fatal("ContainsURL() = true for a different URL")
+	}
+	var nilSuppressions *LinkSuppressions
+	if nilSuppressions.ContainsURL("1:1:0", "https://example.test/course") {
+		t.Fatal("nil ContainsURL() = true")
+	}
+}
+
+func TestLoadLinkSuppressionsAllowsTheSameHashForDifferentEntries(t *testing.T) {
+	hash := hashForTest(t, "https://example.test/shared")
+	suppressions, err := LoadLinkSuppressions(strings.NewReader(`{
+		"schema_version":"link-suppressions/v1",
+		"canonicalization_version":1,
+		"suppressions":[
+			{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"},
+			{"source_entry_id":"1:2:0","sha256":"` + hash + `","reason":"content_mismatch","confirmed_at":"2026-07-27T01:00:00+01:00"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("LoadLinkSuppressions() error = %v", err)
+	}
+	if !suppressions.ContainsURL("1:1:0", "https://example.test/shared") ||
+		!suppressions.ContainsURL("1:2:0", "https://example.test/shared") {
+		t.Fatal("same canonical hash did not match both configured entry occurrences")
+	}
+}
+
+func TestLoadLinkSuppressionsAcceptsEmptySuppressions(t *testing.T) {
+	suppressions, err := LoadLinkSuppressions(strings.NewReader(`{
+		"schema_version":"link-suppressions/v1",
+		"canonicalization_version":1,
+		"suppressions":[]
+	}`))
+	if err != nil {
+		t.Fatalf("LoadLinkSuppressions() error = %v", err)
+	}
+	if suppressions.ContainsURL("1:1:0", "https://example.test/course") {
+		t.Fatal("empty suppressions unexpectedly matched")
+	}
+}
+
+func TestLoadLinkSuppressionsRejectsInvalidFiles(t *testing.T) {
+	hash := hashForTest(t, "https://example.test/course")
+	record := `{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}`
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"invalid utf8", "{\"schema_version\":\"link-suppressions/v1\",\"canonicalization_version\":1,\"suppressions\":[\"\xff\"]}"},
+		{"unknown top-level field", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[],"extra":true}`},
+		{"multiple json values", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[]} {}`},
+		{"duplicate top-level key", `{"schema_version":"link-suppressions/v1","schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[]}`},
+		{"wrong schema", `{"schema_version":"bad","canonicalization_version":1,"suppressions":[]}`},
+		{"wrong canonicalization", `{"schema_version":"link-suppressions/v1","canonicalization_version":2,"suppressions":[]}`},
+		{"missing suppressions", `{"schema_version":"link-suppressions/v1","canonicalization_version":1}`},
+		{"null suppressions", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":null}`},
+		{"ambiguous entry id", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"empty source entry id", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"whitespace source entry id", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":" ","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"empty hash", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"uppercase hash", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"` + strings.ToUpper(hash) + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"short hash", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"abc","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"empty reason", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"unsupported reason", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"expired","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"empty timestamp", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":""}]}`},
+		{"invalid timestamp", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":"not-time"}]}`},
+		{"unknown record field", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z","url":"https://private.invalid"}]}`},
+		{"duplicate record key", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[{"source_entry_id":"1:1:0","source_entry_id":"1:1:0","sha256":"` + hash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}]}`},
+		{"duplicate record", `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[` + record + `,` + record + `]}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := LoadLinkSuppressions(strings.NewReader(test.json)); err == nil {
+				t.Fatal("LoadLinkSuppressions() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestLinkSuppressionsMarshalJSONSortsByEntryAndHashWithoutRawLinkData(t *testing.T) {
+	firstHash := hashForTest(t, "https://example.test/first")
+	secondHash := hashForTest(t, "https://example.test/second")
+	suppressions, err := LoadLinkSuppressions(strings.NewReader(`{
+		"schema_version":"link-suppressions/v1",
+		"canonicalization_version":1,
+		"suppressions":[
+			{"source_entry_id":"2:1:0","sha256":"` + firstHash + `","reason":"manual","confirmed_at":"2026-07-27T02:00:00Z"},
+			{"source_entry_id":"1:1:0","sha256":"` + secondHash + `","reason":"content_mismatch","confirmed_at":"2026-07-27T01:00:00Z"},
+			{"source_entry_id":"1:1:0","sha256":"` + firstHash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("LoadLinkSuppressions() error = %v", err)
+	}
+
+	payload, err := json.Marshal(suppressions)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	want := `{"schema_version":"link-suppressions/v1","canonicalization_version":1,"suppressions":[` +
+		`{"source_entry_id":"1:1:0","sha256":"` + firstHash + `","reason":"manual","confirmed_at":"2026-07-27T00:00:00Z"},` +
+		`{"source_entry_id":"1:1:0","sha256":"` + secondHash + `","reason":"content_mismatch","confirmed_at":"2026-07-27T01:00:00Z"},` +
+		`{"source_entry_id":"2:1:0","sha256":"` + firstHash + `","reason":"manual","confirmed_at":"2026-07-27T02:00:00Z"}]}`
+	if string(payload) != want {
+		t.Fatalf("Marshal() = %s, want %s", payload, want)
+	}
+}
+
+func linkSuppressionsForTest(t *testing.T, sourceEntryID, rawURL string) *LinkSuppressions {
+	t.Helper()
+
+	suppressions, err := LoadLinkSuppressions(strings.NewReader(`{
+		"schema_version":"link-suppressions/v1",
+		"canonicalization_version":1,
+		"suppressions":[{
+			"source_entry_id":"` + sourceEntryID + `",
+			"sha256":"` + hashForTest(t, rawURL) + `",
+			"reason":"manual",
+			"confirmed_at":"2026-07-27T00:00:00Z"
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("LoadLinkSuppressions() error = %v", err)
+	}
+	return suppressions
+}


### PR DESCRIPTION
## Summary

- add strict, hash-only `link-suppressions/v1` loading and deterministic marshaling keyed by `source_entry_id` plus canonical URL SHA-256
- apply suppressions per source occurrence before link-based clustering and during source/torrent link materialization
- expose `suppressed_links_removed` and wire the optional `courses-data --link-suppressions` sidecar

The public repository contains only the generic schema and fixture data; private URLs, hosts, titles, and sidecar contents are not included.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `gopls check` on all changed Go files
- `node --test tests/*.test.js`
- staged diff/privacy scan
- independent review: approved