### PR TITLE
Normalize control characters in embedded link metadata

### DIFF
--- a/internal/courses/link_enrichment.go
+++ b/internal/courses/link_enrichment.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -439,6 +440,24 @@ func linkEnrichmentString(root map[string]any, fieldPath string) (string, error)
 	text, ok := value.(string)
 	if !ok {
 		return "", fmt.Errorf("embedded field %q is not a string", fieldPath)
+	}
+	if containsControlCharacter(text) {
+		controlStripped := strings.Map(func(value rune) rune {
+			if unicode.IsControl(value) {
+				return -1
+			}
+			return value
+		}, text)
+		lower := strings.ToLower(strings.TrimSpace(controlStripped))
+		if strings.Contains(lower, "://") || hasLocatorSchemePrefix(lower) {
+			return "", fmt.Errorf("embedded field %q contains non-metadata content", fieldPath)
+		}
+		text = strings.Map(func(value rune) rune {
+			if unicode.IsControl(value) {
+				return ' '
+			}
+			return value
+		}, text)
 	}
 	text = strings.TrimSpace(text)
 	if len(text) > maxLinkContentStringBytes {

--- a/internal/courses/link_enrichment_cache_test.go
+++ b/internal/courses/link_enrichment_cache_test.go
@@ -142,6 +142,7 @@ func TestLinkEnrichmentCachePutAndWriteRevalidatePrivateSafeInvariants(t *testin
 		"file:/private/path",
 		"urn:secret",
 		"<div>raw html</div>",
+		"bad\u0001value",
 	} {
 		if err := cache.PutExtracted(hash, LinkContent{Name: name}, time.Now()); err == nil {
 			t.Fatalf("PutExtracted(%q) error = nil", name)

--- a/internal/courses/link_enrichment_client_test.go
+++ b/internal/courses/link_enrichment_client_test.go
@@ -181,7 +181,7 @@ func TestEnrichCatalogLinksRefreshesFreshCandidates(t *testing.T) {
 	assertEnrichmentName(t, cache, rawURL, "new")
 }
 
-func TestEnrichCatalogLinksDowngradesInvalidExtractedContentAndKeepsCache(t *testing.T) {
+func TestEnrichCatalogLinksNormalizesControlsAndKeepsCacheOnInvalidContent(t *testing.T) {
 	now := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
 	policy := mustLinkEnrichmentPolicy(t, 10)
 	urls := struct {
@@ -230,8 +230,8 @@ func TestEnrichCatalogLinksDowngradesInvalidExtractedContentAndKeepsCache(t *tes
 	if stats != (LinkEnrichmentStats{
 		Candidates: 5,
 		Fetched:    5,
-		Extracted:  1,
-		Failed:     4,
+		Extracted:  2,
+		Failed:     3,
 	}) {
 		t.Fatalf("stats = %+v", stats)
 	}
@@ -241,7 +241,7 @@ func TestEnrichCatalogLinksDowngradesInvalidExtractedContentAndKeepsCache(t *tes
 	assertEnrichmentName(t, cache, urls.valid, "valid new")
 	assertEnrichmentName(t, cache, urls.locator, "locator old")
 	assertEnrichmentName(t, cache, urls.angle, "angle old")
-	assertEnrichmentName(t, cache, urls.control, "control old")
+	assertEnrichmentName(t, cache, urls.control, "bad value")
 	assertEnrichmentName(t, cache, urls.empty, "empty old")
 }
 

--- a/internal/courses/link_enrichment_test.go
+++ b/internal/courses/link_enrichment_test.go
@@ -68,6 +68,44 @@ func TestLoadLinkEnrichmentPolicyAndExtractEmbeddedObject(t *testing.T) {
 	}
 }
 
+func TestLinkEnrichmentExtractorNormalizesControlCharacters(t *testing.T) {
+	policy := mustLinkEnrichmentPolicy(t, 10)
+	body := []byte(`{"embeddedPayload":{
+		"name":"Example\u0085bundle",
+		"kind":"folder",
+		"list":[{"name":"Lesson\u008efile.mp4","kind":"file","size":1}]
+	}}`)
+
+	content, found, err := policy.Extract("assets.example.test", body)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if !found {
+		t.Fatal("Extract() found = false, want true")
+	}
+	if content.Name != "Example bundle" {
+		t.Fatalf("content.Name = %q, want %q", content.Name, "Example bundle")
+	}
+	if len(content.Items) != 1 {
+		t.Fatalf("len(content.Items) = %d, want 1", len(content.Items))
+	}
+	if content.Items[0].Name != "Lesson file.mp4" {
+		t.Fatalf("content.Items[0].Name = %q, want %q", content.Items[0].Name, "Lesson file.mp4")
+	}
+	if err := validateCachedLinkContent(*content); err != nil {
+		t.Fatalf("validateCachedLinkContent() error = %v", err)
+	}
+
+	for _, body := range []string{
+		`{"embeddedPayload":{"name":"magnet\u0001:?xt=urn:btih:example"}}`,
+		`{"embeddedPayload":{"name":"https\u0001://assets.example.test/private"}}`,
+	} {
+		if _, _, err := policy.Extract("assets.example.test", []byte(body)); err == nil {
+			t.Fatalf("Extract(%q) error = nil", body)
+		}
+	}
+}
+
 func TestLinkEnrichmentExtractorHandlesEscapesAndMissingMarker(t *testing.T) {
 	policy := mustLinkEnrichmentPolicy(t, 10)
 	body := []byte(`<script>{"embeddedPayload":{"name":"A \"quoted\" {bundle}","kind":"folder","size":1,"count":{"files":0,"folders":0},"list":[]}}</script>`)


### PR DESCRIPTION
## What changed

- normalize Unicode control characters in extracted metadata strings before cache validation
- reject control-obfuscated locator schemes before normalization
- keep raw-control rejection at the cache trust boundary
- add extractor, client, and cache regression coverage

## Root cause

The extractor preserved control characters while the cache validator rejected them, so otherwise usable embedded metadata could be discarded. A naive normalization also risked hiding locator prefixes; the stricter pre-normalization check prevents that bypass.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `gopls check` on all modified files
- `git diff --check`
- independent Go review: approved
- independent privacy/spec audit: passed