### PR TITLE
Render link contents in course details

### DIFF
--- a/static/css/courses.css
+++ b/static/css/courses.css
@@ -90,6 +90,7 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 a:focus-visible,
+.link-content-items-toggle:focus-visible,
 dialog:focus-visible {
     outline: 2px solid var(--focus);
     outline-offset: 2px;
@@ -927,6 +928,14 @@ select {
     border-block-end: 1px solid var(--border-soft);
 }
 
+.link-row {
+    align-items: start;
+}
+
+.link-copy {
+    min-width: 0;
+}
+
 .link-value,
 .password-value {
     min-width: 0;
@@ -935,6 +944,78 @@ select {
     font-size: 0.8125rem;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.link-content {
+    min-width: 0;
+    display: grid;
+    grid-column: 1 / -1;
+    gap: 5px;
+    padding-block: 5px 7px;
+}
+
+.link-content-name,
+.link-content-facts {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.link-content-name {
+    color: var(--text);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.link-content-facts {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+.link-content-items {
+    min-width: 0;
+    margin-block-start: 2px;
+}
+
+.link-content-items-toggle {
+    width: fit-content;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 4px;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-weight: 600;
+}
+
+.link-content-items-list {
+    display: grid;
+    margin: 2px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.link-content-item {
+    min-width: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    padding-block: 4px;
+    border-block-start: 1px solid var(--border-soft);
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+.link-content-item-name {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.link-content-item-meta {
+    color: var(--text-muted);
     white-space: nowrap;
 }
 

--- a/static/js/courses.js
+++ b/static/js/courses.js
@@ -6,7 +6,7 @@
     const SEARCH_DELAY_MS = 90;
     const RPC_TIMEOUT_MS = 120_000;
     const MOBILE_BREAKPOINT = 1120;
-    const CONTENT_ITEM_PREVIEW_LIMIT = 3;
+    const CONTENT_ITEMS_OPEN_LIMIT = 8;
     const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "magnet:"]);
     const assetVersion = new URL(document.currentScript.src).searchParams.get("v");
     const MATERIAL_TYPE_LABELS = Object.freeze({
@@ -264,19 +264,11 @@
         return `${russianNumber(number)} ${form}`;
     }
 
-    function formatLinkContentSummary(content) {
+    function formatLinkContentFacts(content) {
         if (!content || typeof content !== "object" || Array.isArray(content)) {
-            return "";
+            return [];
         }
         const parts = [];
-        const name = typeof content.name === "string" && content.name
-            ? content.name
-            : typeof content.kind === "string"
-                ? content.kind
-                : "";
-        if (name) {
-            parts.push(name);
-        }
         if (Number.isSafeInteger(content.size_bytes) && content.size_bytes >= 0) {
             parts.push(formatBytes(content.size_bytes));
         }
@@ -303,18 +295,7 @@
         if (materialLabels.length) {
             parts.push(materialLabels.join(", "));
         }
-
-        const itemNames = Array.isArray(content.items)
-            ? content.items
-                .map((item) => typeof item?.name === "string" ? item.name : "")
-                .filter(Boolean)
-            : [];
-        if (itemNames.length) {
-            const preview = itemNames.slice(0, CONTENT_ITEM_PREVIEW_LIMIT).join(", ");
-            const remaining = itemNames.length - CONTENT_ITEM_PREVIEW_LIMIT;
-            parts.push(remaining > 0 ? `${preview} +${remaining}` : preview);
-        }
-        return parts.join(" · ");
+        return parts;
     }
 
     function formatDate(value, includeTime = false) {
@@ -1041,16 +1022,6 @@
             value.title = link.safeURL;
             const copy = createElement("div", "link-copy");
             copy.append(value);
-            const contentSummary = formatLinkContentSummary(link.content);
-            if (contentSummary) {
-                const summary = createElement(
-                    "p",
-                    "link-value link-content-summary",
-                    contentSummary,
-                );
-                summary.title = contentSummary;
-                copy.append(summary);
-            }
             const actions = createElement("div", "row-actions");
             const open = createElement("button", "button button--quiet", "Открыть");
             open.type = "button";
@@ -1064,10 +1035,72 @@
             ));
             actions.append(open, copyButton);
             item.append(copy, actions);
+            const content = renderLinkContent(link.content);
+            if (content) {
+                item.append(content);
+            }
             list.append(item);
         }
         section.append(list);
         return section;
+    }
+
+    function renderLinkContent(content) {
+        if (!content || typeof content !== "object" || Array.isArray(content)) {
+            return null;
+        }
+
+        const name = typeof content.name === "string" ? content.name.trim() : "";
+        const facts = formatLinkContentFacts(content);
+        const items = Array.isArray(content.items)
+            ? content.items.filter((item) =>
+                item &&
+                typeof item === "object" &&
+                !Array.isArray(item) &&
+                typeof item.name === "string" &&
+                item.name.trim(),
+            )
+            : [];
+        if (!name && !facts.length && !items.length) {
+            return null;
+        }
+
+        const wrapper = createElement("div", "link-content");
+        if (name) {
+            wrapper.append(createElement("p", "link-content-name", name));
+        }
+        if (facts.length) {
+            wrapper.append(createElement("p", "link-content-facts", facts.join(" · ")));
+        }
+        if (items.length) {
+            const details = createElement("details", "link-content-items");
+            details.open = items.length <= CONTENT_ITEMS_OPEN_LIMIT;
+            details.append(createElement(
+                "summary",
+                "link-content-items-toggle",
+                `Содержимое (${russianNumber(items.length)})`,
+            ));
+            const list = createElement("ul", "link-content-items-list");
+            for (const contentItem of items) {
+                const row = createElement("li", "link-content-item");
+                row.append(createElement(
+                    "span",
+                    "link-content-item-name",
+                    contentItem.name.trim(),
+                ));
+                const meta = Number.isSafeInteger(contentItem.size_bytes) &&
+                    contentItem.size_bytes >= 0
+                    ? formatBytes(contentItem.size_bytes)
+                    : contentItem.kind === "folder"
+                        ? "папка"
+                        : "файл";
+                row.append(createElement("span", "link-content-item-meta", meta));
+                list.append(row);
+            }
+            details.append(list);
+            wrapper.append(details);
+        }
+        return wrapper;
     }
 
     function renderPasswordsSection(passwords) {

--- a/tests/courses-default-sort.test.js
+++ b/tests/courses-default-sort.test.js
@@ -145,21 +145,44 @@ window.addEventListener("DOMContentLoaded", async () => {
     await waitFor(() => document.querySelector(".result-select"), "initial result");
     document.querySelector(".result-select").click();
     await waitFor(
-      () => document.querySelectorAll(".link-content-summary").length === 2,
-      "content summaries",
+      () => document.querySelectorAll(".link-content").length === 2,
+      "structured link content",
     );
-    const summaries = [
-      document.querySelector("#desktop-detail .link-content-summary"),
-      document.querySelector("#mobile-detail .link-content-summary"),
+    const contents = [
+      document.querySelector("#desktop-detail .link-content"),
+      document.querySelector("#mobile-detail .link-content"),
     ];
-    const expectedSummary = "Курс <img src=x onerror=alert(1)> · 1,5 ГБ · 7 файлов · 2 папки · архив, видео · intro.mp4, урок 2.mkv, notes.pdf +2";
     expect(
-      summaries.every((summary) => summary && summary.textContent === expectedSummary),
-      "desktop/mobile content summaries differ or are incomplete",
+      contents.every(
+        (content) =>
+          content.querySelector(".link-content-name").textContent ===
+            "Курс <img src=x onerror=alert(1)>" &&
+          content.querySelector(".link-content-facts").textContent ===
+            "1,5 ГБ · 7 файлов · 2 папки · архив, видео" &&
+          content.querySelector(".link-content-items-toggle").textContent ===
+            "Содержимое (5)" &&
+          content.querySelectorAll(".link-content-item").length === 5,
+      ),
+      "desktop/mobile structured content differs or is incomplete",
     );
     expect(
-      summaries.every((summary) => summary.querySelector("img") === null),
+      contents.every(
+        (content) =>
+          content.querySelector(".link-content-item-name").textContent === "intro.mp4" &&
+          content.querySelector(".link-content-item-meta").textContent === "1 Б",
+      ),
+      "content item names or sizes were not rendered",
+    );
+    expect(
+      contents.every((content) => content.querySelector("img") === null),
       "content metadata was interpreted as HTML",
+    );
+    expect(
+      contents.every(
+        (content) =>
+          getComputedStyle(content.querySelector(".link-content-name")).whiteSpace !== "nowrap",
+      ),
+      "content name is still forced into a clipped single line",
     );
 
     search.value = "python";


### PR DESCRIPTION
## Summary

- render link content metadata as a structured block instead of a clipped line
- show content name, aggregate facts, and file entries with sizes
- keep small lists open and collapse larger lists with a native disclosure
- cover desktop and mobile rendering with browser tests

## Root cause

The existing renderer flattened all link content metadata into one paragraph. The shared link-value styles forced that paragraph onto a single ellipsized line, so only the beginning of the content name was visible.

## Validation

- `node --check static/js/courses.js`
- `node --test tests/*.test.js`
- `go test -count=1 ./...`
- `go vet ./...`
- `docker build --platform linux/amd64 -t dummypage:content-visibility .`
- Impeccable layout detector: no findings
- browser QA at desktop and 390x844
